### PR TITLE
Crash onboarding api key restriction

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -33,7 +33,7 @@ export const developerConnectP4SADomain = (): string =>
 export const artifactRegistryDomain = (): string =>
   utils.envOverride("ARTIFACT_REGISTRY_DOMAIN", "https://artifactregistry.googleapis.com");
 export const apiKeysOrigin = (): string =>
-  utils.envOverride("FIREBASE_APIKEYS_URL", "https://apikeys.googleapis.com");
+  utils.envOverride("CLOUD_APIKEYS_URL", "https://apikeys.googleapis.com");
 export const appCheckOrigin = (): string =>
   utils.envOverride("FIREBASE_APPCHECK_URL", "https://firebaseappcheck.googleapis.com");
 export const appDistributionOrigin = (): string =>

--- a/src/api.ts
+++ b/src/api.ts
@@ -32,6 +32,8 @@ export const developerConnectP4SADomain = (): string =>
 
 export const artifactRegistryDomain = (): string =>
   utils.envOverride("ARTIFACT_REGISTRY_DOMAIN", "https://artifactregistry.googleapis.com");
+export const apiKeysOrigin = (): string =>
+  utils.envOverride("FIREBASE_APIKEYS_URL", "https://apikeys.googleapis.com");
 export const appCheckOrigin = (): string =>
   utils.envOverride("FIREBASE_APPCHECK_URL", "https://firebaseappcheck.googleapis.com");
 export const appDistributionOrigin = (): string =>

--- a/src/crashlytics/onboarding.spec.ts
+++ b/src/crashlytics/onboarding.spec.ts
@@ -9,6 +9,7 @@ import * as cloudbilling from "../gcp/cloudbilling";
 import * as firebasetelemetry from "./firebasetelemetry";
 import * as apps from "../management/apps";
 import * as apikeys from "../gcp/apikeys";
+import * as utils from "../utils";
 import { FirebaseError } from "../error";
 
 describe("onboarding", () => {
@@ -19,6 +20,7 @@ describe("onboarding", () => {
   let checkBillingStub: sinon.SinonStub;
   let getAppConfigStub: sinon.SinonStub;
   let updateAppApiKeyRestrictionStub: sinon.SinonStub;
+  let logLabeledWarningStub: sinon.SinonStub;
 
   before(() => {
     nock.disableNetConnect();
@@ -52,6 +54,7 @@ describe("onboarding", () => {
       apiKey: "fake-api-key-123",
     });
     updateAppApiKeyRestrictionStub = sinon.stub(apikeys, "updateAppApiKeyRestriction").resolves();
+    logLabeledWarningStub = sinon.stub(utils, "logLabeledWarning");
   });
 
   afterEach(() => {
@@ -76,14 +79,14 @@ describe("onboarding", () => {
       "projects/test-project/locations/global/buckets/firebase-telemetry",
       1,
     );
-    expect(updateAppApiKeyRestrictionStub).to.have.been.calledWith(
-      "fake-api-key-123",
-      "firebasetelemetry.googleapis.com",
-    );
+    expect(updateAppApiKeyRestrictionStub).to.have.been.calledWith({
+      apiKey: "fake-api-key-123",
+      service: onboarding.CRASHLYTICS_TELEMETRY_SERVICE,
+    });
     expect(res.config.enablementState).to.equal("ENABLED");
   });
 
-  it("should successfully onboard web app without calling updateAppApiKeyRestriction if apiKey is missing", async () => {
+  it("should successfully onboard web app and log a warning without calling updateAppApiKeyRestriction if apiKey is missing", async () => {
     getAppConfigStub.resolves({
       projectId: "test-project",
     });
@@ -105,6 +108,22 @@ describe("onboarding", () => {
       1,
     );
     expect(updateAppApiKeyRestrictionStub).to.not.have.been.called;
+    expect(logLabeledWarningStub).to.have.been.calledWith(
+      "crashlytics",
+      `No API key found for this app. If you configure an API key later, ` +
+        `please rerun this command or manually add '${onboarding.CRASHLYTICS_TELEMETRY_SERVICE}' to its allowed APIs in the Google Cloud Console if the key is restricted.`,
+    );
+    expect(res.config.enablementState).to.equal("ENABLED");
+  });
+
+  it("should successfully onboard web app and log a warning if updateAppApiKeyRestriction throws an error", async () => {
+    const fakeError = new FirebaseError("Failed to update API key restriction");
+    updateAppApiKeyRestrictionStub.rejects(fakeError);
+
+    const res = await onboarding.onboardCrashlyticsWeb("test-project", "1:123:web:456");
+
+    expect(updateAppApiKeyRestrictionStub).to.have.been.calledOnce;
+    expect(logLabeledWarningStub).to.have.been.calledWith("crashlytics", fakeError.message);
     expect(res.config.enablementState).to.equal("ENABLED");
   });
 

--- a/src/crashlytics/onboarding.spec.ts
+++ b/src/crashlytics/onboarding.spec.ts
@@ -7,6 +7,8 @@ import * as ensureApiEnabled from "../ensureApiEnabled";
 import * as cloudlogging from "../gcp/cloudlogging";
 import * as cloudbilling from "../gcp/cloudbilling";
 import * as firebasetelemetry from "./firebasetelemetry";
+import * as apps from "../management/apps";
+import * as apikeys from "../gcp/apikeys";
 import { FirebaseError } from "../error";
 
 describe("onboarding", () => {
@@ -15,6 +17,8 @@ describe("onboarding", () => {
   let sinkStub: sinon.SinonStub;
   let configStub: sinon.SinonStub;
   let checkBillingStub: sinon.SinonStub;
+  let getAppConfigStub: sinon.SinonStub;
+  let updateAppApiKeyRestrictionStub: sinon.SinonStub;
 
   before(() => {
     nock.disableNetConnect();
@@ -43,6 +47,11 @@ describe("onboarding", () => {
       samplingRate: 1,
       enablementState: "ENABLED",
     });
+    getAppConfigStub = sinon.stub(apps, "getAppConfig").resolves({
+      projectId: "test-project",
+      apiKey: "fake-api-key-123",
+    });
+    updateAppApiKeyRestrictionStub = sinon.stub(apikeys, "updateAppApiKeyRestriction").resolves();
   });
 
   afterEach(() => {
@@ -67,6 +76,35 @@ describe("onboarding", () => {
       "projects/test-project/locations/global/buckets/firebase-telemetry",
       1,
     );
+    expect(updateAppApiKeyRestrictionStub).to.have.been.calledWith(
+      "fake-api-key-123",
+      "firebasetelemetry.googleapis.com",
+    );
+    expect(res.config.enablementState).to.equal("ENABLED");
+  });
+
+  it("should successfully onboard web app without calling updateAppApiKeyRestriction if apiKey is missing", async () => {
+    getAppConfigStub.resolves({
+      projectId: "test-project",
+    });
+
+    const res = await onboarding.onboardCrashlyticsWeb("test-project", "1:123:web:456");
+
+    expect(ensureStub).to.have.been.calledTwice;
+    expect(bucketStub).to.have.been.calledWith(
+      "test-project",
+      "firebase-telemetry",
+      "global",
+      true,
+    );
+    expect(sinkStub).to.have.been.calledOnce;
+    expect(configStub).to.have.been.calledWith(
+      "test-project",
+      "1:123:web:456",
+      "projects/test-project/locations/global/buckets/firebase-telemetry",
+      1,
+    );
+    expect(updateAppApiKeyRestrictionStub).to.not.have.been.called;
     expect(res.config.enablementState).to.equal("ENABLED");
   });
 

--- a/src/crashlytics/onboarding.ts
+++ b/src/crashlytics/onboarding.ts
@@ -8,14 +8,14 @@ import {
   LogSink,
 } from "../gcp/cloudlogging";
 import { createOrUpdateTelemetryConfig, TelemetryConfig } from "./firebasetelemetry";
-import { logLabeledBullet, logLabeledSuccess } from "../utils";
+import { logLabeledBullet, logLabeledSuccess, logLabeledWarning } from "../utils";
 import { updateAppApiKeyRestriction } from "../gcp/apikeys";
 import { AppPlatform, getAppConfig } from "../management/apps";
-import { WebConfig } from "../fetchWebSetup";
 
 export const CRASHLYTICS_TELEMETRY_BUCKET_ID = "firebase-telemetry";
 export const CRASHLYTICS_TELEMETRY_SINK_ID = "firebase-telemetry-routing";
 export const CRASHLYTICS_TELEMETRY_RESOURCE_TYPE = "firebasetelemetry.googleapis.com/App";
+export const CRASHLYTICS_TELEMETRY_SERVICE = "firebasetelemetry.googleapis.com";
 
 export interface OnboardWebResult {
   bucket: LogBucket;
@@ -44,17 +44,33 @@ export async function onboardCrashlyticsWeb(
 
   logLabeledBullet("crashlytics", "Enabling required telemetry APIs...");
   await Promise.all([
-    ensure(projectId, "firebasetelemetry.googleapis.com", "crashlytics", false),
+    ensure(projectId, CRASHLYTICS_TELEMETRY_SERVICE, "crashlytics", false),
     ensure(projectId, "firebasetelemetryadmin.googleapis.com", "crashlytics", false),
   ]);
   logLabeledSuccess("crashlytics", "Telemetry APIs enabled.");
 
-  logLabeledBullet("crashlytics", "Enabling API key restriction for telemetry APIs...");
-  const appConfig = (await getAppConfig(appId, AppPlatform.WEB)) as WebConfig;
-  if (appConfig.apiKey) {
-    await updateAppApiKeyRestriction(appConfig.apiKey, "firebasetelemetry.googleapis.com");
+  const appConfig = await getAppConfig(appId, AppPlatform.WEB);
+  if ("apiKey" in appConfig && appConfig.apiKey) {
+    logLabeledBullet(
+      "crashlytics",
+      "Ensuring Crashlytics Telemetry API is permitted in API key restrictions...",
+    );
+    try {
+      await updateAppApiKeyRestriction({
+        apiKey: appConfig.apiKey,
+        service: CRASHLYTICS_TELEMETRY_SERVICE,
+      });
+      logLabeledSuccess("crashlytics", "API key restrictions updated for Crashlytics Telemetry.");
+    } catch (err: unknown) {
+      logLabeledWarning("crashlytics", err instanceof Error ? err.message : String(err));
+    }
+  } else {
+    logLabeledWarning(
+      "crashlytics",
+      `No API key found for this app. If you configure an API key later, ` +
+        `please rerun this command or manually add '${CRASHLYTICS_TELEMETRY_SERVICE}' to its allowed APIs in the Google Cloud Console if the key is restricted.`,
+    );
   }
-  logLabeledSuccess("crashlytics", "API key restriction for telemetry APIs enabled.");
 
   logLabeledBullet(
     "crashlytics",

--- a/src/crashlytics/onboarding.ts
+++ b/src/crashlytics/onboarding.ts
@@ -9,6 +9,9 @@ import {
 } from "../gcp/cloudlogging";
 import { createOrUpdateTelemetryConfig, TelemetryConfig } from "./firebasetelemetry";
 import { logLabeledBullet, logLabeledSuccess } from "../utils";
+import { updateAppApiKeyRestriction } from "../gcp/apikeys";
+import { AppPlatform, getAppConfig } from "../management/apps";
+import { WebConfig } from "../fetchWebSetup";
 
 export const CRASHLYTICS_TELEMETRY_BUCKET_ID = "firebase-telemetry";
 export const CRASHLYTICS_TELEMETRY_SINK_ID = "firebase-telemetry-routing";
@@ -45,6 +48,13 @@ export async function onboardCrashlyticsWeb(
     ensure(projectId, "firebasetelemetryadmin.googleapis.com", "crashlytics", false),
   ]);
   logLabeledSuccess("crashlytics", "Telemetry APIs enabled.");
+
+  logLabeledBullet("crashlytics", "Enabling API key restriction for telemetry APIs...");
+  const appConfig = (await getAppConfig(appId, AppPlatform.WEB)) as WebConfig;
+  if (appConfig.apiKey) {
+    await updateAppApiKeyRestriction(appConfig.apiKey, "firebasetelemetry.googleapis.com");
+  }
+  logLabeledSuccess("crashlytics", "API key restriction for telemetry APIs enabled.");
 
   logLabeledBullet(
     "crashlytics",

--- a/src/gcp/apikeys.spec.ts
+++ b/src/gcp/apikeys.spec.ts
@@ -2,19 +2,11 @@ import { expect } from "chai";
 import * as sinon from "sinon";
 import nock from "../test/helpers/nock";
 
+import { Key } from "./apikeys";
 import * as apikeys from "./apikeys";
 import { apiKeysOrigin } from "../api";
 import * as operationPoller from "../operation-poller";
 import { FirebaseError } from "../error";
-
-interface TestKey {
-  name: string;
-  displayName?: string;
-  keyString?: string;
-  restrictions?: {
-    apiTargets?: Array<{ service: string; methods?: string[] }>;
-  };
-}
 
 const PROJECT_ID = "test-project";
 const TEST_KEY_RESOURCE_NAME = `projects/${PROJECT_ID}/locations/global/keys/test-key`;
@@ -43,7 +35,7 @@ describe("apikeys", () => {
     const TEST_KEY_PATH = `/v2/${TEST_KEY_RESOURCE_NAME}`;
 
     it("should not patch an unrestricted key with empty restrictions", async () => {
-      const emptyRestrictionsKey: TestKey = {
+      const emptyRestrictionsKey: Key = {
         name: TEST_KEY_RESOURCE_NAME,
         displayName: "Empty Restrictions Key",
         restrictions: {},
@@ -64,7 +56,7 @@ describe("apikeys", () => {
     });
 
     it("should not patch an unrestricted key with empty apiTargets", async () => {
-      const emptyApiTargetsKey: TestKey = {
+      const emptyApiTargetsKey: Key = {
         name: TEST_KEY_RESOURCE_NAME,
         displayName: "Empty apiTargets Key",
         restrictions: {
@@ -87,7 +79,7 @@ describe("apikeys", () => {
     });
 
     it("should not patch a restricted already allowed key", async () => {
-      const restrictedAlreadyAllowedKey: TestKey = {
+      const restrictedAlreadyAllowedKey: Key = {
         name: TEST_KEY_RESOURCE_NAME,
         displayName: "Already Allowed Key",
         restrictions: {
@@ -111,7 +103,7 @@ describe("apikeys", () => {
 
     it("should patch a restricted key to include the missing service restriction with polling", async () => {
       const existingServiceName = "existingservice.googleapis.com";
-      const restrictedMissingKey: TestKey = {
+      const restrictedMissingKey: Key = {
         name: TEST_KEY_RESOURCE_NAME,
         displayName: "Restricted Key",
         restrictions: {
@@ -127,7 +119,7 @@ describe("apikeys", () => {
       nock(apiKeysOrigin()).get(TEST_KEY_PATH).reply(200, restrictedMissingKey);
 
       const patchReq = nock(apiKeysOrigin())
-        .patch(TEST_KEY_PATH, (body: TestKey) => {
+        .patch(TEST_KEY_PATH, (body: Key) => {
           expect(body.restrictions?.apiTargets).to.deep.equal([
             { service: existingServiceName },
             { service: serviceName },
@@ -179,7 +171,7 @@ describe("apikeys", () => {
 
     it("should throw FirebaseError with key display name when updateKey API returns 403", async () => {
       const existingServiceName = "existingservice.googleapis.com";
-      const restrictedMissingKey: TestKey = {
+      const restrictedMissingKey: Key = {
         name: TEST_KEY_RESOURCE_NAME,
         displayName: "Restricted Key",
         restrictions: {

--- a/src/gcp/apikeys.spec.ts
+++ b/src/gcp/apikeys.spec.ts
@@ -7,6 +7,19 @@ import { apiKeysOrigin } from "../api";
 import * as operationPoller from "../operation-poller";
 import { FirebaseError } from "../error";
 
+interface TestKey {
+  name: string;
+  displayName?: string;
+  keyString?: string;
+  restrictions?: {
+    apiTargets?: Array<{ service: string; methods?: string[] }>;
+  };
+}
+
+const PROJECT_ID = "test-project";
+const TEST_KEY_RESOURCE_NAME = `projects/${PROJECT_ID}/locations/global/keys/test-key`;
+const LOOKUP_KEYS_PATH = "/v2/keys:lookupKey";
+
 describe("apikeys", () => {
   const sandbox = sinon.createSandbox();
 
@@ -23,496 +36,160 @@ describe("apikeys", () => {
     nock.cleanAll();
   });
 
-  describe("lookupKey", () => {
-    it("should resolve with key lookup metadata on success", async () => {
-      const lookupResponse: apikeys.LookupKeyResponse = {
-        name: "projects/12345/locations/global/keys/abcd-1234",
-        parent: "projects/12345/locations/global",
-        displayName: "Browser key",
-      };
+  describe("updateAppApiKeyRestriction", () => {
+    const apiKeyString = "AIzaSyFakeKeyString";
+    const serviceName = "testservice.googleapis.com";
 
-      nock(apiKeysOrigin())
-        .get("/v2/keys:lookupKey")
-        .query({ keyString: "AIzaSyFakeKeyString" })
-        .reply(200, lookupResponse);
+    const PATCH_TEST_KEY_PATH = `/v2/${TEST_KEY_RESOURCE_NAME}`;
 
-      const res = await apikeys.lookupKey("AIzaSyFakeKeyString");
-      expect(res).to.deep.equal(lookupResponse);
-    });
-
-    it("should throw FirebaseError with instructions when 403 Forbidden is returned", async () => {
-      nock(apiKeysOrigin())
-        .get("/v2/keys:lookupKey")
-        .query({ keyString: "AIzaSyFakeKeyString" })
-        .reply(403, { error: { message: "The caller does not have permission" } });
-
-      await expect(apikeys.lookupKey("AIzaSyFakeKeyString")).to.be.rejectedWith(
-        FirebaseError,
-        /Permission denied when looking up API key/,
-      );
-    });
-
-    it("should reject with original error if API returns non-403 error", async () => {
-      nock(apiKeysOrigin())
-        .get("/v2/keys:lookupKey")
-        .query({ keyString: "invalid-key" })
-        .reply(404, { error: { message: "Key not found" } });
-
-      await expect(apikeys.lookupKey("invalid-key")).to.be.rejected;
-    });
-  });
-
-  describe("getKey", () => {
-    it("should resolve with the key resource", async () => {
-      const key: apikeys.Key = {
-        name: "projects/12345/locations/global/keys/abcd-1234",
-        displayName: "Browser key",
-        restrictions: {
-          apiTargets: [{ service: "identitytoolkit.googleapis.com" }],
-        },
-      };
-
-      nock(apiKeysOrigin())
-        .get("/v2/projects/12345/locations/global/keys/abcd-1234")
-        .reply(200, key);
-
-      const res = await apikeys.getKey("projects/12345/locations/global/keys/abcd-1234");
-      expect(res).to.deep.equal(key);
-    });
-
-    it("should throw FirebaseError with key name and console link when 403 Forbidden is returned", async () => {
-      nock(apiKeysOrigin())
-        .get("/v2/projects/12345/locations/global/keys/abcd-1234")
-        .reply(403, { error: { message: "Permission denied" } });
-
-      await expect(
-        apikeys.getKey("projects/12345/locations/global/keys/abcd-1234"),
-      ).to.be.rejectedWith(
-        FirebaseError,
-        /Permission denied when retrieving API key projects\/12345\/locations\/global\/keys\/abcd-1234/,
-      );
-    });
-  });
-
-  describe("getKeyByString", () => {
-    it("should lookup and fetch the full key resource", async () => {
-      const lookupResponse: apikeys.LookupKeyResponse = {
-        name: "projects/12345/locations/global/keys/abcd-1234",
-        parent: "projects/12345/locations/global",
-        displayName: "Browser key",
-      };
-      const key: apikeys.Key = {
-        name: "projects/12345/locations/global/keys/abcd-1234",
-        displayName: "Browser key",
+    it("should not patch an unrestricted key with empty restrictions", async () => {
+      const emptyRestrictionsKey: TestKey = {
+        name: TEST_KEY_RESOURCE_NAME,
+        displayName: "Empty Restrictions Key",
         restrictions: {},
       };
 
       nock(apiKeysOrigin())
-        .get("/v2/keys:lookupKey")
-        .query({ keyString: "AIzaSyFakeKeyString" })
-        .reply(200, lookupResponse);
+        .get(LOOKUP_KEYS_PATH)
+        .query({ keyString: apiKeyString })
+        .reply(200, { name: TEST_KEY_RESOURCE_NAME });
 
-      nock(apiKeysOrigin())
-        .get("/v2/projects/12345/locations/global/keys/abcd-1234")
-        .reply(200, key);
+      nock(apiKeysOrigin()).get(PATCH_TEST_KEY_PATH).reply(200, emptyRestrictionsKey);
 
-      const res = await apikeys.getKeyByString("AIzaSyFakeKeyString");
-      expect(res).to.deep.equal(key);
-    });
-  });
-
-  describe("listKeys", () => {
-    it("should list all keys for a project across multiple pages", async () => {
-      const page1Keys: apikeys.Key[] = [
-        { name: "projects/test-project/locations/global/keys/key-1", displayName: "Key 1" },
-      ];
-      const page2Keys: apikeys.Key[] = [
-        { name: "projects/test-project/locations/global/keys/key-2", displayName: "Key 2" },
-      ];
-
-      nock(apiKeysOrigin())
-        .get("/v2/projects/test-project/locations/global/keys")
-        .reply(200, { keys: page1Keys, nextPageToken: "page-2-token" });
-
-      nock(apiKeysOrigin())
-        .get("/v2/projects/test-project/locations/global/keys")
-        .query({ pageToken: "page-2-token" })
-        .reply(200, { keys: page2Keys });
-
-      const res = await apikeys.listKeys("test-project");
-      expect(res).to.deep.equal([...page1Keys, ...page2Keys]);
+      await apikeys.updateAppApiKeyRestriction(apiKeyString, serviceName);
     });
 
-    it("should return empty array if no keys are found", async () => {
-      nock(apiKeysOrigin()).get("/v2/projects/test-project/locations/global/keys").reply(200, {});
-
-      const res = await apikeys.listKeys("test-project");
-      expect(res).to.deep.equal([]);
-    });
-
-    it("should throw FirebaseError with project ID when 403 Forbidden is returned", async () => {
-      nock(apiKeysOrigin())
-        .get("/v2/projects/test-project/locations/global/keys")
-        .reply(403, { error: { message: "Permission denied" } });
-
-      await expect(apikeys.listKeys("test-project")).to.be.rejectedWith(
-        FirebaseError,
-        /Permission denied when listing API keys for project test-project/,
-      );
-    });
-  });
-
-  describe("updateKey", () => {
-    it("should return the response directly when LRO is already done", async () => {
-      const updatedKey: apikeys.Key = {
-        name: "projects/12345/locations/global/keys/abcd-1234",
-        displayName: "Browser key",
-        restrictions: {
-          apiTargets: [{ service: "firebasetelemetry.googleapis.com" }],
-        },
-      };
-
-      nock(apiKeysOrigin())
-        .patch("/v2/projects/12345/locations/global/keys/abcd-1234")
-        .query({ updateMask: "restrictions" })
-        .reply(200, {
-          name: "operations/op-123",
-          done: true,
-          response: updatedKey,
-        });
-
-      const res = await apikeys.updateKey(updatedKey, ["restrictions"]);
-      expect(res).to.deep.equal(updatedKey);
-    });
-
-    it("should poll the operation when LRO is not immediately done", async () => {
-      const updatedKey: apikeys.Key = {
-        name: "projects/12345/locations/global/keys/abcd-1234",
-        displayName: "Browser key",
-        restrictions: {
-          apiTargets: [{ service: "firebasetelemetry.googleapis.com" }],
-        },
-      };
-
-      nock(apiKeysOrigin())
-        .patch("/v2/projects/12345/locations/global/keys/abcd-1234")
-        .query({ updateMask: "restrictions" })
-        .reply(200, {
-          name: "operations/op-123",
-          done: false,
-        });
-
-      sandbox.stub(operationPoller, "pollOperation").resolves(updatedKey);
-
-      const res = await apikeys.updateKey(updatedKey, ["restrictions"]);
-      expect(res).to.deep.equal(updatedKey);
-      expect(operationPoller.pollOperation).to.have.been.calledWith({
-        apiOrigin: apiKeysOrigin(),
-        apiVersion: "v2",
-        operationResourceName: "operations/op-123",
-      });
-    });
-
-    it("should throw FirebaseError with key name and console link when 403 Forbidden is returned", async () => {
-      const keyToUpdate: apikeys.Key = {
-        name: "projects/test-project/locations/global/keys/abcd-1234",
-        displayName: "Web App Key",
-        restrictions: {
-          apiTargets: [{ service: "firebasetelemetry.googleapis.com" }],
-        },
-      };
-
-      nock(apiKeysOrigin())
-        .patch("/v2/projects/test-project/locations/global/keys/abcd-1234")
-        .query({ updateMask: "restrictions" })
-        .reply(403, { error: { message: "Permission denied" } });
-
-      await expect(apikeys.updateKey(keyToUpdate, ["restrictions"])).to.be.rejectedWith(
-        FirebaseError,
-        /Permission denied when updating API key Web App Key \(projects\/test-project\/locations\/global\/keys\/abcd-1234\)/,
-      );
-    });
-  });
-
-  describe("ensureServiceInKeyRestrictions", () => {
-    it("should do nothing if key has no apiTargets restrictions (unrestricted)", async () => {
-      const key: apikeys.Key = {
-        name: "projects/12345/locations/global/keys/abcd-1234",
-        displayName: "Browser key",
-        restrictions: {
-          browserKeyRestrictions: { allowedReferrers: ["https://example.com/*"] },
-        },
-      };
-
-      nock(apiKeysOrigin())
-        .get("/v2/keys:lookupKey")
-        .query({ keyString: "AIzaSyFakeKeyString" })
-        .reply(200, { name: key.name });
-
-      nock(apiKeysOrigin())
-        .get("/v2/projects/12345/locations/global/keys/abcd-1234")
-        .reply(200, key);
-
-      const res = await apikeys.ensureServiceInKeyRestrictions(
-        "AIzaSyFakeKeyString",
-        "firebasetelemetry.googleapis.com",
-      );
-
-      expect(res.updated).to.be.false;
-      expect(res.key).to.deep.equal(key);
-    });
-
-    it("should accept a Key object directly without looking up keyString", async () => {
-      const key: apikeys.Key = {
-        name: "projects/12345/locations/global/keys/abcd-1234",
-        displayName: "Browser key",
-        restrictions: {
-          apiTargets: [{ service: "identitytoolkit.googleapis.com" }],
-        },
-      };
-
-      const updatedKey: apikeys.Key = {
-        ...key,
-        restrictions: {
-          apiTargets: [
-            { service: "identitytoolkit.googleapis.com" },
-            { service: "firebasetelemetry.googleapis.com" },
-          ],
-        },
-      };
-
-      nock(apiKeysOrigin())
-        .patch("/v2/projects/12345/locations/global/keys/abcd-1234")
-        .query({ updateMask: "restrictions" })
-        .reply(200, {
-          name: "operations/op-123",
-          done: true,
-          response: updatedKey,
-        });
-
-      const res = await apikeys.ensureServiceInKeyRestrictions(
-        key,
-        "firebasetelemetry.googleapis.com",
-      );
-
-      expect(res.updated).to.be.true;
-      expect(res.key).to.deep.equal(updatedKey);
-    });
-
-    it("should do nothing if apiTargets is empty", async () => {
-      const key: apikeys.Key = {
-        name: "projects/12345/locations/global/keys/abcd-1234",
-        displayName: "Browser key",
+    it("should not patch an unrestricted key with empty apiTargets", async () => {
+      const emptyApiTargetsKey: TestKey = {
+        name: TEST_KEY_RESOURCE_NAME,
+        displayName: "Empty apiTargets Key",
         restrictions: {
           apiTargets: [],
         },
       };
 
       nock(apiKeysOrigin())
-        .get("/v2/keys:lookupKey")
-        .query({ keyString: "AIzaSyFakeKeyString" })
-        .reply(200, { name: key.name });
+        .get(LOOKUP_KEYS_PATH)
+        .query({ keyString: apiKeyString })
+        .reply(200, { name: TEST_KEY_RESOURCE_NAME });
 
-      nock(apiKeysOrigin())
-        .get("/v2/projects/12345/locations/global/keys/abcd-1234")
-        .reply(200, key);
+      nock(apiKeysOrigin()).get(PATCH_TEST_KEY_PATH).reply(200, emptyApiTargetsKey);
 
-      const res = await apikeys.ensureServiceInKeyRestrictions(
-        "AIzaSyFakeKeyString",
-        "firebasetelemetry.googleapis.com",
-      );
-
-      expect(res.updated).to.be.false;
-      expect(res.key).to.deep.equal(key);
+      await apikeys.updateAppApiKeyRestriction(apiKeyString, serviceName);
     });
 
-    it("should do nothing if the service is already present in apiTargets", async () => {
-      const key: apikeys.Key = {
-        name: "projects/12345/locations/global/keys/abcd-1234",
-        displayName: "Browser key",
+    it("should not patch a restricted already allowed key", async () => {
+      const restrictedAlreadyAllowedKey: TestKey = {
+        name: TEST_KEY_RESOURCE_NAME,
+        displayName: "Already Allowed Key",
         restrictions: {
-          apiTargets: [
-            { service: "identitytoolkit.googleapis.com" },
-            { service: "firebasetelemetry.googleapis.com" },
-          ],
+          apiTargets: [{ service: serviceName }],
         },
       };
 
       nock(apiKeysOrigin())
-        .get("/v2/keys:lookupKey")
-        .query({ keyString: "AIzaSyFakeKeyString" })
-        .reply(200, { name: key.name });
+        .get(LOOKUP_KEYS_PATH)
+        .query({ keyString: apiKeyString })
+        .reply(200, { name: TEST_KEY_RESOURCE_NAME });
 
-      nock(apiKeysOrigin())
-        .get("/v2/projects/12345/locations/global/keys/abcd-1234")
-        .reply(200, key);
+      nock(apiKeysOrigin()).get(PATCH_TEST_KEY_PATH).reply(200, restrictedAlreadyAllowedKey);
 
-      const res = await apikeys.ensureServiceInKeyRestrictions(
-        "AIzaSyFakeKeyString",
-        "firebasetelemetry.googleapis.com",
-      );
-
-      expect(res.updated).to.be.false;
-      expect(res.key).to.deep.equal(key);
+      await apikeys.updateAppApiKeyRestriction(apiKeyString, serviceName);
     });
 
-    it("should append service and update key when apiTargets is restricted and missing the service", async () => {
-      const existingKey: apikeys.Key = {
-        name: "projects/12345/locations/global/keys/abcd-1234",
-        displayName: "Browser key",
+    it("should patch a restricted key to include the missing service restriction with polling", async () => {
+      const existingServiceName = "existingservice.googleapis.com";
+      const restrictedMissingKey: TestKey = {
+        name: TEST_KEY_RESOURCE_NAME,
+        displayName: "Restricted Key",
         restrictions: {
-          apiTargets: [{ service: "identitytoolkit.googleapis.com" }],
-        },
-      };
-
-      const updatedKey: apikeys.Key = {
-        ...existingKey,
-        restrictions: {
-          apiTargets: [
-            { service: "identitytoolkit.googleapis.com" },
-            { service: "firebasetelemetry.googleapis.com" },
-          ],
+          apiTargets: [{ service: existingServiceName }],
         },
       };
 
       nock(apiKeysOrigin())
-        .get("/v2/keys:lookupKey")
-        .query({ keyString: "AIzaSyFakeKeyString" })
-        .reply(200, { name: existingKey.name });
+        .get(LOOKUP_KEYS_PATH)
+        .query({ keyString: apiKeyString })
+        .reply(200, { name: TEST_KEY_RESOURCE_NAME });
 
-      nock(apiKeysOrigin())
-        .get("/v2/projects/12345/locations/global/keys/abcd-1234")
-        .reply(200, existingKey);
+      nock(apiKeysOrigin()).get(PATCH_TEST_KEY_PATH).reply(200, restrictedMissingKey);
 
-      nock(apiKeysOrigin())
-        .patch("/v2/projects/12345/locations/global/keys/abcd-1234", (body: apikeys.Key) => {
+      const request = nock(apiKeysOrigin())
+        .patch(PATCH_TEST_KEY_PATH, (body: TestKey) => {
           expect(body.restrictions?.apiTargets).to.deep.equal([
-            { service: "identitytoolkit.googleapis.com" },
-            { service: "firebasetelemetry.googleapis.com" },
+            { service: existingServiceName },
+            { service: serviceName },
           ]);
           return true;
         })
         .query({ updateMask: "restrictions" })
-        .reply(200, {
-          name: "operations/op-123",
-          done: true,
-          response: updatedKey,
-        });
+        .reply(200, { name: "operations/op-123" });
 
-      const res = await apikeys.ensureServiceInKeyRestrictions(
-        "AIzaSyFakeKeyString",
-        "firebasetelemetry.googleapis.com",
-      );
+      const pollStub = sandbox.stub(operationPoller, "pollOperation").resolves();
 
-      expect(res.updated).to.be.true;
-      expect(res.key).to.deep.equal(updatedKey);
+      await apikeys.updateAppApiKeyRestriction(apiKeyString, serviceName);
+      expect(request.isDone()).to.be.true;
+      expect(pollStub).to.have.been.calledWith({
+        apiOrigin: apiKeysOrigin(),
+        apiVersion: "v2",
+        operationResourceName: "operations/op-123",
+      });
     });
-  });
 
-  describe("ensureServiceInProjectKeyRestrictions", () => {
-    it("should update restricted keys missing the service and skip unrestricted/already-allowed keys", async () => {
-      const unrestrictedKey: apikeys.Key = {
-        name: "projects/test-project/locations/global/keys/key-1",
-        displayName: "Unrestricted Key",
-        restrictions: {},
-      };
-      const alreadyAllowedKey: apikeys.Key = {
-        name: "projects/test-project/locations/global/keys/key-2",
-        displayName: "Already Allowed Key",
-        restrictions: {
-          apiTargets: [{ service: "firebasetelemetry.googleapis.com" }],
-        },
-      };
-      const restrictedKey: apikeys.Key = {
-        name: "projects/test-project/locations/global/keys/key-3",
+    it("should throw FirebaseError when lookup API returns 403", async () => {
+      nock(apiKeysOrigin())
+        .get(LOOKUP_KEYS_PATH)
+        .query({ keyString: apiKeyString })
+        .reply(403, { error: { message: "Permission denied" } });
+
+      await expect(
+        apikeys.updateAppApiKeyRestriction(apiKeyString, serviceName),
+      ).to.be.rejectedWith(FirebaseError, /Permission denied when looking up API key/);
+    });
+
+    it("should throw FirebaseError with key resource name when getKeyWithResourceName API returns 403", async () => {
+      nock(apiKeysOrigin())
+        .get(LOOKUP_KEYS_PATH)
+        .query({ keyString: apiKeyString })
+        .reply(200, { name: TEST_KEY_RESOURCE_NAME });
+
+      nock(apiKeysOrigin())
+        .get(PATCH_TEST_KEY_PATH)
+        .reply(403, { error: { message: "Permission denied" } });
+
+      await expect(
+        apikeys.updateAppApiKeyRestriction(apiKeyString, serviceName),
+      ).to.be.rejectedWith(
+        FirebaseError,
+        /Permission denied when retrieving API key projects\/test-project\/locations\/global\/keys\/test-key/,
+      );
+    });
+
+    it("should throw FirebaseError with key display name when updateKey API returns 403", async () => {
+      const existingServiceName = "existingservice.googleapis.com";
+      const restrictedMissingKey: TestKey = {
+        name: TEST_KEY_RESOURCE_NAME,
         displayName: "Restricted Key",
         restrictions: {
-          apiTargets: [{ service: "identitytoolkit.googleapis.com" }],
-        },
-      };
-      const updatedRestrictedKey: apikeys.Key = {
-        ...restrictedKey,
-        restrictions: {
-          apiTargets: [
-            { service: "identitytoolkit.googleapis.com" },
-            { service: "firebasetelemetry.googleapis.com" },
-          ],
+          apiTargets: [{ service: existingServiceName }],
         },
       };
 
       nock(apiKeysOrigin())
-        .get("/v2/projects/test-project/locations/global/keys")
-        .reply(200, { keys: [unrestrictedKey, alreadyAllowedKey, restrictedKey] });
+        .get(LOOKUP_KEYS_PATH)
+        .query({ keyString: apiKeyString })
+        .reply(200, { name: TEST_KEY_RESOURCE_NAME });
+
+      nock(apiKeysOrigin()).get(PATCH_TEST_KEY_PATH).reply(200, restrictedMissingKey);
 
       nock(apiKeysOrigin())
-        .patch("/v2/projects/test-project/locations/global/keys/key-3")
+        .patch(PATCH_TEST_KEY_PATH)
         .query({ updateMask: "restrictions" })
-        .reply(200, {
-          name: "operations/op-123",
-          done: true,
-          response: updatedRestrictedKey,
-        });
+        .reply(403, { error: { message: "Permission denied" } });
 
-      const res = await apikeys.ensureServiceInProjectKeyRestrictions(
-        "test-project",
-        "firebasetelemetry.googleapis.com",
-      );
-
-      expect(res.updatedKeys).to.deep.equal([updatedRestrictedKey]);
-      expect(res.unchangedKeys).to.deep.equal([unrestrictedKey, alreadyAllowedKey]);
-    });
-  });
-
-  describe("updateProjectKeyRestrictions", () => {
-    it("should apply updater function across all project keys", async () => {
-      const key1: apikeys.Key = {
-        name: "projects/test-project/locations/global/keys/key-1",
-        displayName: "Key 1",
-        restrictions: {
-          browserKeyRestrictions: { allowedReferrers: ["https://old.example.com/*"] },
-        },
-      };
-      const key2: apikeys.Key = {
-        name: "projects/test-project/locations/global/keys/key-2",
-        displayName: "Key 2",
-        restrictions: {},
-      };
-
-      const updatedKey1: apikeys.Key = {
-        ...key1,
-        restrictions: {
-          browserKeyRestrictions: { allowedReferrers: ["https://new.example.com/*"] },
-        },
-      };
-
-      nock(apiKeysOrigin())
-        .get("/v2/projects/test-project/locations/global/keys")
-        .reply(200, { keys: [key1, key2] });
-
-      nock(apiKeysOrigin())
-        .patch("/v2/projects/test-project/locations/global/keys/key-1")
-        .query({ updateMask: "restrictions" })
-        .reply(200, {
-          name: "operations/op-123",
-          done: true,
-          response: updatedKey1,
-        });
-
-      const res = await apikeys.updateProjectKeyRestrictions(
-        "test-project",
-        (restrictions, key) => {
-          if (key.name === key1.name) {
-            return {
-              ...restrictions,
-              browserKeyRestrictions: { allowedReferrers: ["https://new.example.com/*"] },
-            };
-          }
-          return undefined; // Skip key2
-        },
-      );
-
-      expect(res.updatedKeys).to.deep.equal([updatedKey1]);
-      expect(res.unchangedKeys).to.deep.equal([key2]);
+      await expect(
+        apikeys.updateAppApiKeyRestriction(apiKeyString, serviceName),
+      ).to.be.rejectedWith(FirebaseError, /Permission denied when updating API key Restricted Key/);
     });
   });
 });

--- a/src/gcp/apikeys.spec.ts
+++ b/src/gcp/apikeys.spec.ts
@@ -50,7 +50,7 @@ describe("apikeys", () => {
 
       const patchReq = nock(apiKeysOrigin()).patch(TEST_KEY_PATH).reply(200);
 
-      await apikeys.updateAppApiKeyRestriction(apiKeyString, serviceName);
+      await apikeys.updateAppApiKeyRestriction({ apiKey: apiKeyString, service: serviceName });
 
       expect(patchReq.isDone()).to.be.false;
     });
@@ -73,7 +73,7 @@ describe("apikeys", () => {
 
       const patchReq = nock(apiKeysOrigin()).patch(TEST_KEY_PATH).reply(200);
 
-      await apikeys.updateAppApiKeyRestriction(apiKeyString, serviceName);
+      await apikeys.updateAppApiKeyRestriction({ apiKey: apiKeyString, service: serviceName });
 
       expect(patchReq.isDone()).to.be.false;
     });
@@ -96,7 +96,7 @@ describe("apikeys", () => {
 
       const patchReq = nock(apiKeysOrigin()).patch(TEST_KEY_PATH).reply(200);
 
-      await apikeys.updateAppApiKeyRestriction(apiKeyString, serviceName);
+      await apikeys.updateAppApiKeyRestriction({ apiKey: apiKeyString, service: serviceName });
 
       expect(patchReq.isDone()).to.be.false;
     });
@@ -131,7 +131,7 @@ describe("apikeys", () => {
 
       const pollStub = sandbox.stub(operationPoller, "pollOperation").resolves();
 
-      await apikeys.updateAppApiKeyRestriction(apiKeyString, serviceName);
+      await apikeys.updateAppApiKeyRestriction({ apiKey: apiKeyString, service: serviceName });
       expect(patchReq.isDone()).to.be.true;
       expect(pollStub).to.have.been.calledWith({
         apiOrigin: apiKeysOrigin(),
@@ -147,7 +147,7 @@ describe("apikeys", () => {
         .reply(403, { error: { message: "Permission denied" } });
 
       await expect(
-        apikeys.updateAppApiKeyRestriction(apiKeyString, serviceName),
+        apikeys.updateAppApiKeyRestriction({ apiKey: apiKeyString, service: serviceName }),
       ).to.be.rejectedWith(FirebaseError, /Permission denied when looking up API key/);
     });
 
@@ -162,7 +162,7 @@ describe("apikeys", () => {
         .reply(403, { error: { message: "Permission denied" } });
 
       await expect(
-        apikeys.updateAppApiKeyRestriction(apiKeyString, serviceName),
+        apikeys.updateAppApiKeyRestriction({ apiKey: apiKeyString, service: serviceName }),
       ).to.be.rejectedWith(
         FirebaseError,
         /Permission denied when retrieving API key projects\/test-project\/locations\/global\/keys\/test-key/,
@@ -192,7 +192,7 @@ describe("apikeys", () => {
         .reply(403, { error: { message: "Permission denied" } });
 
       await expect(
-        apikeys.updateAppApiKeyRestriction(apiKeyString, serviceName),
+        apikeys.updateAppApiKeyRestriction({ apiKey: apiKeyString, service: serviceName }),
       ).to.be.rejectedWith(FirebaseError, /Permission denied when updating API key Restricted Key/);
     });
   });

--- a/src/gcp/apikeys.spec.ts
+++ b/src/gcp/apikeys.spec.ts
@@ -40,7 +40,7 @@ describe("apikeys", () => {
     const apiKeyString = "AIzaSyFakeKeyString";
     const serviceName = "testservice.googleapis.com";
 
-    const PATCH_TEST_KEY_PATH = `/v2/${TEST_KEY_RESOURCE_NAME}`;
+    const TEST_KEY_PATH = `/v2/${TEST_KEY_RESOURCE_NAME}`;
 
     it("should not patch an unrestricted key with empty restrictions", async () => {
       const emptyRestrictionsKey: TestKey = {
@@ -54,7 +54,7 @@ describe("apikeys", () => {
         .query({ keyString: apiKeyString })
         .reply(200, { name: TEST_KEY_RESOURCE_NAME });
 
-      nock(apiKeysOrigin()).get(PATCH_TEST_KEY_PATH).reply(200, emptyRestrictionsKey);
+      nock(apiKeysOrigin()).get(TEST_KEY_PATH).reply(200, emptyRestrictionsKey);
 
       await apikeys.updateAppApiKeyRestriction(apiKeyString, serviceName);
     });
@@ -73,7 +73,7 @@ describe("apikeys", () => {
         .query({ keyString: apiKeyString })
         .reply(200, { name: TEST_KEY_RESOURCE_NAME });
 
-      nock(apiKeysOrigin()).get(PATCH_TEST_KEY_PATH).reply(200, emptyApiTargetsKey);
+      nock(apiKeysOrigin()).get(TEST_KEY_PATH).reply(200, emptyApiTargetsKey);
 
       await apikeys.updateAppApiKeyRestriction(apiKeyString, serviceName);
     });
@@ -92,7 +92,7 @@ describe("apikeys", () => {
         .query({ keyString: apiKeyString })
         .reply(200, { name: TEST_KEY_RESOURCE_NAME });
 
-      nock(apiKeysOrigin()).get(PATCH_TEST_KEY_PATH).reply(200, restrictedAlreadyAllowedKey);
+      nock(apiKeysOrigin()).get(TEST_KEY_PATH).reply(200, restrictedAlreadyAllowedKey);
 
       await apikeys.updateAppApiKeyRestriction(apiKeyString, serviceName);
     });
@@ -112,10 +112,10 @@ describe("apikeys", () => {
         .query({ keyString: apiKeyString })
         .reply(200, { name: TEST_KEY_RESOURCE_NAME });
 
-      nock(apiKeysOrigin()).get(PATCH_TEST_KEY_PATH).reply(200, restrictedMissingKey);
+      nock(apiKeysOrigin()).get(TEST_KEY_PATH).reply(200, restrictedMissingKey);
 
       const request = nock(apiKeysOrigin())
-        .patch(PATCH_TEST_KEY_PATH, (body: TestKey) => {
+        .patch(TEST_KEY_PATH, (body: TestKey) => {
           expect(body.restrictions?.apiTargets).to.deep.equal([
             { service: existingServiceName },
             { service: serviceName },
@@ -154,7 +154,7 @@ describe("apikeys", () => {
         .reply(200, { name: TEST_KEY_RESOURCE_NAME });
 
       nock(apiKeysOrigin())
-        .get(PATCH_TEST_KEY_PATH)
+        .get(TEST_KEY_PATH)
         .reply(403, { error: { message: "Permission denied" } });
 
       await expect(
@@ -180,10 +180,10 @@ describe("apikeys", () => {
         .query({ keyString: apiKeyString })
         .reply(200, { name: TEST_KEY_RESOURCE_NAME });
 
-      nock(apiKeysOrigin()).get(PATCH_TEST_KEY_PATH).reply(200, restrictedMissingKey);
+      nock(apiKeysOrigin()).get(TEST_KEY_PATH).reply(200, restrictedMissingKey);
 
       nock(apiKeysOrigin())
-        .patch(PATCH_TEST_KEY_PATH)
+        .patch(TEST_KEY_PATH)
         .query({ updateMask: "restrictions" })
         .reply(403, { error: { message: "Permission denied" } });
 

--- a/src/gcp/apikeys.spec.ts
+++ b/src/gcp/apikeys.spec.ts
@@ -1,0 +1,466 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+import nock from "../test/helpers/nock";
+
+import * as apikeys from "./apikeys";
+import { apiKeysOrigin } from "../api";
+import * as operationPoller from "../operation-poller";
+
+describe("apikeys", () => {
+  const sandbox = sinon.createSandbox();
+
+  before(() => {
+    nock.disableNetConnect();
+  });
+
+  after(() => {
+    nock.enableNetConnect();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    nock.cleanAll();
+  });
+
+  describe("lookupKey", () => {
+    it("should resolve with key lookup metadata on success", async () => {
+      const lookupResponse: apikeys.LookupKeyResponse = {
+        name: "projects/12345/locations/global/keys/abcd-1234",
+        parent: "projects/12345/locations/global",
+        displayName: "Browser key",
+      };
+
+      nock(apiKeysOrigin())
+        .get("/v2/keys:lookupKey")
+        .query({ keyString: "AIzaSyFakeKeyString" })
+        .reply(200, lookupResponse);
+
+      const res = await apikeys.lookupKey("AIzaSyFakeKeyString");
+      expect(res).to.deep.equal(lookupResponse);
+    });
+
+    it("should reject if API returns an error", async () => {
+      nock(apiKeysOrigin())
+        .get("/v2/keys:lookupKey")
+        .query({ keyString: "invalid-key" })
+        .reply(404, { error: { message: "Key not found" } });
+
+      await expect(apikeys.lookupKey("invalid-key")).to.be.rejected;
+    });
+  });
+
+  describe("getKey", () => {
+    it("should resolve with the key resource", async () => {
+      const key: apikeys.Key = {
+        name: "projects/12345/locations/global/keys/abcd-1234",
+        displayName: "Browser key",
+        restrictions: {
+          apiTargets: [{ service: "identitytoolkit.googleapis.com" }],
+        },
+      };
+
+      nock(apiKeysOrigin())
+        .get("/v2/projects/12345/locations/global/keys/abcd-1234")
+        .reply(200, key);
+
+      const res = await apikeys.getKey("projects/12345/locations/global/keys/abcd-1234");
+      expect(res).to.deep.equal(key);
+    });
+  });
+
+  describe("getKeyByString", () => {
+    it("should lookup and fetch the full key resource", async () => {
+      const lookupResponse: apikeys.LookupKeyResponse = {
+        name: "projects/12345/locations/global/keys/abcd-1234",
+        parent: "projects/12345/locations/global",
+        displayName: "Browser key",
+      };
+      const key: apikeys.Key = {
+        name: "projects/12345/locations/global/keys/abcd-1234",
+        displayName: "Browser key",
+        restrictions: {},
+      };
+
+      nock(apiKeysOrigin())
+        .get("/v2/keys:lookupKey")
+        .query({ keyString: "AIzaSyFakeKeyString" })
+        .reply(200, lookupResponse);
+
+      nock(apiKeysOrigin())
+        .get("/v2/projects/12345/locations/global/keys/abcd-1234")
+        .reply(200, key);
+
+      const res = await apikeys.getKeyByString("AIzaSyFakeKeyString");
+      expect(res).to.deep.equal(key);
+    });
+  });
+
+  describe("listKeys", () => {
+    it("should list all keys for a project across multiple pages", async () => {
+      const page1Keys: apikeys.Key[] = [
+        { name: "projects/test-project/locations/global/keys/key-1", displayName: "Key 1" },
+      ];
+      const page2Keys: apikeys.Key[] = [
+        { name: "projects/test-project/locations/global/keys/key-2", displayName: "Key 2" },
+      ];
+
+      nock(apiKeysOrigin())
+        .get("/v2/projects/test-project/locations/global/keys")
+        .reply(200, { keys: page1Keys, nextPageToken: "page-2-token" });
+
+      nock(apiKeysOrigin())
+        .get("/v2/projects/test-project/locations/global/keys")
+        .query({ pageToken: "page-2-token" })
+        .reply(200, { keys: page2Keys });
+
+      const res = await apikeys.listKeys("test-project");
+      expect(res).to.deep.equal([...page1Keys, ...page2Keys]);
+    });
+
+    it("should return empty array if no keys are found", async () => {
+      nock(apiKeysOrigin())
+        .get("/v2/projects/test-project/locations/global/keys")
+        .reply(200, {});
+
+      const res = await apikeys.listKeys("test-project");
+      expect(res).to.deep.equal([]);
+    });
+  });
+
+  describe("updateKey", () => {
+    it("should return the response directly when LRO is already done", async () => {
+      const updatedKey: apikeys.Key = {
+        name: "projects/12345/locations/global/keys/abcd-1234",
+        displayName: "Browser key",
+        restrictions: {
+          apiTargets: [{ service: "firebasetelemetry.googleapis.com" }],
+        },
+      };
+
+      nock(apiKeysOrigin())
+        .patch("/v2/projects/12345/locations/global/keys/abcd-1234")
+        .query({ updateMask: "restrictions" })
+        .reply(200, {
+          name: "operations/op-123",
+          done: true,
+          response: updatedKey,
+        });
+
+      const res = await apikeys.updateKey(updatedKey, ["restrictions"]);
+      expect(res).to.deep.equal(updatedKey);
+    });
+
+    it("should poll the operation when LRO is not immediately done", async () => {
+      const updatedKey: apikeys.Key = {
+        name: "projects/12345/locations/global/keys/abcd-1234",
+        displayName: "Browser key",
+        restrictions: {
+          apiTargets: [{ service: "firebasetelemetry.googleapis.com" }],
+        },
+      };
+
+      nock(apiKeysOrigin())
+        .patch("/v2/projects/12345/locations/global/keys/abcd-1234")
+        .query({ updateMask: "restrictions" })
+        .reply(200, {
+          name: "operations/op-123",
+          done: false,
+        });
+
+      sandbox.stub(operationPoller, "pollOperation").resolves(updatedKey);
+
+      const res = await apikeys.updateKey(updatedKey, ["restrictions"]);
+      expect(res).to.deep.equal(updatedKey);
+      expect(operationPoller.pollOperation).to.have.been.calledWith({
+        apiOrigin: apiKeysOrigin(),
+        apiVersion: "v2",
+        operationResourceName: "operations/op-123",
+      });
+    });
+  });
+
+  describe("ensureServiceInKeyRestrictions", () => {
+    it("should do nothing if key has no apiTargets restrictions (unrestricted)", async () => {
+      const key: apikeys.Key = {
+        name: "projects/12345/locations/global/keys/abcd-1234",
+        displayName: "Browser key",
+        restrictions: {
+          browserKeyRestrictions: { allowedReferrers: ["https://example.com/*"] },
+        },
+      };
+
+      nock(apiKeysOrigin())
+        .get("/v2/keys:lookupKey")
+        .query({ keyString: "AIzaSyFakeKeyString" })
+        .reply(200, { name: key.name });
+
+      nock(apiKeysOrigin())
+        .get("/v2/projects/12345/locations/global/keys/abcd-1234")
+        .reply(200, key);
+
+      const res = await apikeys.ensureServiceInKeyRestrictions(
+        "AIzaSyFakeKeyString",
+        "firebasetelemetry.googleapis.com",
+      );
+
+      expect(res.updated).to.be.false;
+      expect(res.key).to.deep.equal(key);
+    });
+
+    it("should accept a Key object directly without looking up keyString", async () => {
+      const key: apikeys.Key = {
+        name: "projects/12345/locations/global/keys/abcd-1234",
+        displayName: "Browser key",
+        restrictions: {
+          apiTargets: [{ service: "identitytoolkit.googleapis.com" }],
+        },
+      };
+
+      const updatedKey: apikeys.Key = {
+        ...key,
+        restrictions: {
+          apiTargets: [
+            { service: "identitytoolkit.googleapis.com" },
+            { service: "firebasetelemetry.googleapis.com" },
+          ],
+        },
+      };
+
+      nock(apiKeysOrigin())
+        .patch("/v2/projects/12345/locations/global/keys/abcd-1234")
+        .query({ updateMask: "restrictions" })
+        .reply(200, {
+          name: "operations/op-123",
+          done: true,
+          response: updatedKey,
+        });
+
+      const res = await apikeys.ensureServiceInKeyRestrictions(
+        key,
+        "firebasetelemetry.googleapis.com",
+      );
+
+      expect(res.updated).to.be.true;
+      expect(res.key).to.deep.equal(updatedKey);
+    });
+
+    it("should do nothing if apiTargets is empty", async () => {
+      const key: apikeys.Key = {
+        name: "projects/12345/locations/global/keys/abcd-1234",
+        displayName: "Browser key",
+        restrictions: {
+          apiTargets: [],
+        },
+      };
+
+      nock(apiKeysOrigin())
+        .get("/v2/keys:lookupKey")
+        .query({ keyString: "AIzaSyFakeKeyString" })
+        .reply(200, { name: key.name });
+
+      nock(apiKeysOrigin())
+        .get("/v2/projects/12345/locations/global/keys/abcd-1234")
+        .reply(200, key);
+
+      const res = await apikeys.ensureServiceInKeyRestrictions(
+        "AIzaSyFakeKeyString",
+        "firebasetelemetry.googleapis.com",
+      );
+
+      expect(res.updated).to.be.false;
+      expect(res.key).to.deep.equal(key);
+    });
+
+    it("should do nothing if the service is already present in apiTargets", async () => {
+      const key: apikeys.Key = {
+        name: "projects/12345/locations/global/keys/abcd-1234",
+        displayName: "Browser key",
+        restrictions: {
+          apiTargets: [
+            { service: "identitytoolkit.googleapis.com" },
+            { service: "firebasetelemetry.googleapis.com" },
+          ],
+        },
+      };
+
+      nock(apiKeysOrigin())
+        .get("/v2/keys:lookupKey")
+        .query({ keyString: "AIzaSyFakeKeyString" })
+        .reply(200, { name: key.name });
+
+      nock(apiKeysOrigin())
+        .get("/v2/projects/12345/locations/global/keys/abcd-1234")
+        .reply(200, key);
+
+      const res = await apikeys.ensureServiceInKeyRestrictions(
+        "AIzaSyFakeKeyString",
+        "firebasetelemetry.googleapis.com",
+      );
+
+      expect(res.updated).to.be.false;
+      expect(res.key).to.deep.equal(key);
+    });
+
+    it("should append service and update key when apiTargets is restricted and missing the service", async () => {
+      const existingKey: apikeys.Key = {
+        name: "projects/12345/locations/global/keys/abcd-1234",
+        displayName: "Browser key",
+        restrictions: {
+          apiTargets: [{ service: "identitytoolkit.googleapis.com" }],
+        },
+      };
+
+      const updatedKey: apikeys.Key = {
+        ...existingKey,
+        restrictions: {
+          apiTargets: [
+            { service: "identitytoolkit.googleapis.com" },
+            { service: "firebasetelemetry.googleapis.com" },
+          ],
+        },
+      };
+
+      nock(apiKeysOrigin())
+        .get("/v2/keys:lookupKey")
+        .query({ keyString: "AIzaSyFakeKeyString" })
+        .reply(200, { name: existingKey.name });
+
+      nock(apiKeysOrigin())
+        .get("/v2/projects/12345/locations/global/keys/abcd-1234")
+        .reply(200, existingKey);
+
+      nock(apiKeysOrigin())
+        .patch(
+          "/v2/projects/12345/locations/global/keys/abcd-1234",
+          (body: apikeys.Key) => {
+            expect(body.restrictions?.apiTargets).to.deep.equal([
+              { service: "identitytoolkit.googleapis.com" },
+              { service: "firebasetelemetry.googleapis.com" },
+            ]);
+            return true;
+          },
+        )
+        .query({ updateMask: "restrictions" })
+        .reply(200, {
+          name: "operations/op-123",
+          done: true,
+          response: updatedKey,
+        });
+
+      const res = await apikeys.ensureServiceInKeyRestrictions(
+        "AIzaSyFakeKeyString",
+        "firebasetelemetry.googleapis.com",
+      );
+
+      expect(res.updated).to.be.true;
+      expect(res.key).to.deep.equal(updatedKey);
+    });
+  });
+
+  describe("ensureServiceInProjectKeyRestrictions", () => {
+    it("should update restricted keys missing the service and skip unrestricted/already-allowed keys", async () => {
+      const unrestrictedKey: apikeys.Key = {
+        name: "projects/test-project/locations/global/keys/key-1",
+        displayName: "Unrestricted Key",
+        restrictions: {},
+      };
+      const alreadyAllowedKey: apikeys.Key = {
+        name: "projects/test-project/locations/global/keys/key-2",
+        displayName: "Already Allowed Key",
+        restrictions: {
+          apiTargets: [{ service: "firebasetelemetry.googleapis.com" }],
+        },
+      };
+      const restrictedKey: apikeys.Key = {
+        name: "projects/test-project/locations/global/keys/key-3",
+        displayName: "Restricted Key",
+        restrictions: {
+          apiTargets: [{ service: "identitytoolkit.googleapis.com" }],
+        },
+      };
+      const updatedRestrictedKey: apikeys.Key = {
+        ...restrictedKey,
+        restrictions: {
+          apiTargets: [
+            { service: "identitytoolkit.googleapis.com" },
+            { service: "firebasetelemetry.googleapis.com" },
+          ],
+        },
+      };
+
+      nock(apiKeysOrigin())
+        .get("/v2/projects/test-project/locations/global/keys")
+        .reply(200, { keys: [unrestrictedKey, alreadyAllowedKey, restrictedKey] });
+
+      nock(apiKeysOrigin())
+        .patch("/v2/projects/test-project/locations/global/keys/key-3")
+        .query({ updateMask: "restrictions" })
+        .reply(200, {
+          name: "operations/op-123",
+          done: true,
+          response: updatedRestrictedKey,
+        });
+
+      const res = await apikeys.ensureServiceInProjectKeyRestrictions(
+        "test-project",
+        "firebasetelemetry.googleapis.com",
+      );
+
+      expect(res.updatedKeys).to.deep.equal([updatedRestrictedKey]);
+      expect(res.unchangedKeys).to.deep.equal([unrestrictedKey, alreadyAllowedKey]);
+    });
+  });
+
+  describe("updateProjectKeyRestrictions", () => {
+    it("should apply updater function across all project keys", async () => {
+      const key1: apikeys.Key = {
+        name: "projects/test-project/locations/global/keys/key-1",
+        displayName: "Key 1",
+        restrictions: {
+          browserKeyRestrictions: { allowedReferrers: ["https://old.example.com/*"] },
+        },
+      };
+      const key2: apikeys.Key = {
+        name: "projects/test-project/locations/global/keys/key-2",
+        displayName: "Key 2",
+        restrictions: {},
+      };
+
+      const updatedKey1: apikeys.Key = {
+        ...key1,
+        restrictions: {
+          browserKeyRestrictions: { allowedReferrers: ["https://new.example.com/*"] },
+        },
+      };
+
+      nock(apiKeysOrigin())
+        .get("/v2/projects/test-project/locations/global/keys")
+        .reply(200, { keys: [key1, key2] });
+
+      nock(apiKeysOrigin())
+        .patch("/v2/projects/test-project/locations/global/keys/key-1")
+        .query({ updateMask: "restrictions" })
+        .reply(200, {
+          name: "operations/op-123",
+          done: true,
+          response: updatedKey1,
+        });
+
+      const res = await apikeys.updateProjectKeyRestrictions(
+        "test-project",
+        (restrictions, key) => {
+          if (key.name === key1.name) {
+            return {
+              ...restrictions,
+              browserKeyRestrictions: { allowedReferrers: ["https://new.example.com/*"] },
+            };
+          }
+          return undefined; // Skip key2
+        },
+      );
+
+      expect(res.updatedKeys).to.deep.equal([updatedKey1]);
+      expect(res.unchangedKeys).to.deep.equal([key2]);
+    });
+  });
+});

--- a/src/gcp/apikeys.spec.ts
+++ b/src/gcp/apikeys.spec.ts
@@ -56,7 +56,11 @@ describe("apikeys", () => {
 
       nock(apiKeysOrigin()).get(TEST_KEY_PATH).reply(200, emptyRestrictionsKey);
 
+      const patchReq = nock(apiKeysOrigin()).patch(TEST_KEY_PATH).reply(200);
+
       await apikeys.updateAppApiKeyRestriction(apiKeyString, serviceName);
+
+      expect(patchReq.isDone()).to.be.false;
     });
 
     it("should not patch an unrestricted key with empty apiTargets", async () => {
@@ -75,7 +79,11 @@ describe("apikeys", () => {
 
       nock(apiKeysOrigin()).get(TEST_KEY_PATH).reply(200, emptyApiTargetsKey);
 
+      const patchReq = nock(apiKeysOrigin()).patch(TEST_KEY_PATH).reply(200);
+
       await apikeys.updateAppApiKeyRestriction(apiKeyString, serviceName);
+
+      expect(patchReq.isDone()).to.be.false;
     });
 
     it("should not patch a restricted already allowed key", async () => {
@@ -94,7 +102,11 @@ describe("apikeys", () => {
 
       nock(apiKeysOrigin()).get(TEST_KEY_PATH).reply(200, restrictedAlreadyAllowedKey);
 
+      const patchReq = nock(apiKeysOrigin()).patch(TEST_KEY_PATH).reply(200);
+
       await apikeys.updateAppApiKeyRestriction(apiKeyString, serviceName);
+
+      expect(patchReq.isDone()).to.be.false;
     });
 
     it("should patch a restricted key to include the missing service restriction with polling", async () => {
@@ -114,7 +126,7 @@ describe("apikeys", () => {
 
       nock(apiKeysOrigin()).get(TEST_KEY_PATH).reply(200, restrictedMissingKey);
 
-      const request = nock(apiKeysOrigin())
+      const patchReq = nock(apiKeysOrigin())
         .patch(TEST_KEY_PATH, (body: TestKey) => {
           expect(body.restrictions?.apiTargets).to.deep.equal([
             { service: existingServiceName },
@@ -128,7 +140,7 @@ describe("apikeys", () => {
       const pollStub = sandbox.stub(operationPoller, "pollOperation").resolves();
 
       await apikeys.updateAppApiKeyRestriction(apiKeyString, serviceName);
-      expect(request.isDone()).to.be.true;
+      expect(patchReq.isDone()).to.be.true;
       expect(pollStub).to.have.been.calledWith({
         apiOrigin: apiKeysOrigin(),
         apiVersion: "v2",

--- a/src/gcp/apikeys.spec.ts
+++ b/src/gcp/apikeys.spec.ts
@@ -5,6 +5,7 @@ import nock from "../test/helpers/nock";
 import * as apikeys from "./apikeys";
 import { apiKeysOrigin } from "../api";
 import * as operationPoller from "../operation-poller";
+import { FirebaseError } from "../error";
 
 describe("apikeys", () => {
   const sandbox = sinon.createSandbox();
@@ -39,7 +40,19 @@ describe("apikeys", () => {
       expect(res).to.deep.equal(lookupResponse);
     });
 
-    it("should reject if API returns an error", async () => {
+    it("should throw FirebaseError with instructions when 403 Forbidden is returned", async () => {
+      nock(apiKeysOrigin())
+        .get("/v2/keys:lookupKey")
+        .query({ keyString: "AIzaSyFakeKeyString" })
+        .reply(403, { error: { message: "The caller does not have permission" } });
+
+      await expect(apikeys.lookupKey("AIzaSyFakeKeyString")).to.be.rejectedWith(
+        FirebaseError,
+        /Permission denied when looking up API key/,
+      );
+    });
+
+    it("should reject with original error if API returns non-403 error", async () => {
       nock(apiKeysOrigin())
         .get("/v2/keys:lookupKey")
         .query({ keyString: "invalid-key" })
@@ -65,6 +78,19 @@ describe("apikeys", () => {
 
       const res = await apikeys.getKey("projects/12345/locations/global/keys/abcd-1234");
       expect(res).to.deep.equal(key);
+    });
+
+    it("should throw FirebaseError with key name and console link when 403 Forbidden is returned", async () => {
+      nock(apiKeysOrigin())
+        .get("/v2/projects/12345/locations/global/keys/abcd-1234")
+        .reply(403, { error: { message: "Permission denied" } });
+
+      await expect(
+        apikeys.getKey("projects/12345/locations/global/keys/abcd-1234"),
+      ).to.be.rejectedWith(
+        FirebaseError,
+        /Permission denied when retrieving API key projects\/12345\/locations\/global\/keys\/abcd-1234/,
+      );
     });
   });
 
@@ -118,12 +144,21 @@ describe("apikeys", () => {
     });
 
     it("should return empty array if no keys are found", async () => {
-      nock(apiKeysOrigin())
-        .get("/v2/projects/test-project/locations/global/keys")
-        .reply(200, {});
+      nock(apiKeysOrigin()).get("/v2/projects/test-project/locations/global/keys").reply(200, {});
 
       const res = await apikeys.listKeys("test-project");
       expect(res).to.deep.equal([]);
+    });
+
+    it("should throw FirebaseError with project ID when 403 Forbidden is returned", async () => {
+      nock(apiKeysOrigin())
+        .get("/v2/projects/test-project/locations/global/keys")
+        .reply(403, { error: { message: "Permission denied" } });
+
+      await expect(apikeys.listKeys("test-project")).to.be.rejectedWith(
+        FirebaseError,
+        /Permission denied when listing API keys for project test-project/,
+      );
     });
   });
 
@@ -176,6 +211,26 @@ describe("apikeys", () => {
         apiVersion: "v2",
         operationResourceName: "operations/op-123",
       });
+    });
+
+    it("should throw FirebaseError with key name and console link when 403 Forbidden is returned", async () => {
+      const keyToUpdate: apikeys.Key = {
+        name: "projects/test-project/locations/global/keys/abcd-1234",
+        displayName: "Web App Key",
+        restrictions: {
+          apiTargets: [{ service: "firebasetelemetry.googleapis.com" }],
+        },
+      };
+
+      nock(apiKeysOrigin())
+        .patch("/v2/projects/test-project/locations/global/keys/abcd-1234")
+        .query({ updateMask: "restrictions" })
+        .reply(403, { error: { message: "Permission denied" } });
+
+      await expect(apikeys.updateKey(keyToUpdate, ["restrictions"])).to.be.rejectedWith(
+        FirebaseError,
+        /Permission denied when updating API key Web App Key \(projects\/test-project\/locations\/global\/keys\/abcd-1234\)/,
+      );
     });
   });
 
@@ -330,16 +385,13 @@ describe("apikeys", () => {
         .reply(200, existingKey);
 
       nock(apiKeysOrigin())
-        .patch(
-          "/v2/projects/12345/locations/global/keys/abcd-1234",
-          (body: apikeys.Key) => {
-            expect(body.restrictions?.apiTargets).to.deep.equal([
-              { service: "identitytoolkit.googleapis.com" },
-              { service: "firebasetelemetry.googleapis.com" },
-            ]);
-            return true;
-          },
-        )
+        .patch("/v2/projects/12345/locations/global/keys/abcd-1234", (body: apikeys.Key) => {
+          expect(body.restrictions?.apiTargets).to.deep.equal([
+            { service: "identitytoolkit.googleapis.com" },
+            { service: "firebasetelemetry.googleapis.com" },
+          ]);
+          return true;
+        })
         .query({ updateMask: "restrictions" })
         .reply(200, {
           name: "operations/op-123",

--- a/src/gcp/apikeys.ts
+++ b/src/gcp/apikeys.ts
@@ -1,0 +1,245 @@
+import { apiKeysOrigin } from "../api";
+import { Client } from "../apiv2";
+import { OperationResult, pollOperation } from "../operation-poller";
+
+export const API_VERSION = "v2";
+
+export const client = new Client({
+  urlPrefix: apiKeysOrigin(),
+  auth: true,
+  apiVersion: API_VERSION,
+});
+
+export interface ApiTarget {
+  service: string;
+  methods?: string[];
+}
+
+export interface AndroidApplication {
+  sha1Fingerprint: string;
+  packageName: string;
+}
+
+export interface AndroidKeyRestrictions {
+  allowedApplications: AndroidApplication[];
+}
+
+export interface IosKeyRestrictions {
+  allowedBundleIds: string[];
+}
+
+export interface BrowserKeyRestrictions {
+  allowedReferrers: string[];
+}
+
+export interface ServerKeyRestrictions {
+  allowedIps: string[];
+}
+
+export interface Restrictions {
+  apiTargets?: ApiTarget[];
+  browserKeyRestrictions?: BrowserKeyRestrictions;
+  serverKeyRestrictions?: ServerKeyRestrictions;
+  androidKeyRestrictions?: AndroidKeyRestrictions;
+  iosKeyRestrictions?: IosKeyRestrictions;
+}
+
+export interface Key {
+  name: string;
+  uid?: string;
+  displayName?: string;
+  keyString?: string;
+  restrictions?: Restrictions;
+  etag?: string;
+  createTime?: string;
+  updateTime?: string;
+  deleteTime?: string;
+}
+
+export interface LookupKeyResponse {
+  name: string;
+  parent: string;
+  displayName?: string;
+}
+
+/**
+ * Looks up the key resource name and parent for a given API key string.
+ * Ref: https://cloud.google.com/api-keys/docs/reference/rest/v2/keys/lookupKey
+ */
+export async function lookupKey(keyString: string): Promise<LookupKeyResponse> {
+  const res = await client.get<LookupKeyResponse>("/keys:lookupKey", {
+    queryParams: { keyString },
+  });
+  return res.body;
+}
+
+/**
+ * Gets the details of an API key given its resource name.
+ * Ref: https://cloud.google.com/api-keys/docs/reference/rest/v2/projects.locations.keys/get
+ */
+export async function getKey(keyName: string): Promise<Key> {
+  const path = keyName.startsWith("/") ? keyName : `/${keyName}`;
+  const res = await client.get<Key>(path);
+  return res.body;
+}
+
+/**
+ * Retrieves an API key's full resource by its key string.
+ */
+export async function getKeyByString(keyString: string): Promise<Key> {
+  const lookup = await lookupKey(keyString);
+  return getKey(lookup.name);
+}
+
+/**
+ * Updates the properties of an API key, tracking the long-running operation until completion.
+ * Ref: https://cloud.google.com/api-keys/docs/reference/rest/v2/projects.locations.keys/patch
+ */
+export async function updateKey(key: Key, updateMask: string[] = ["restrictions"]): Promise<Key> {
+  const queryParams: Record<string, string> = {};
+  if (updateMask.length > 0) {
+    queryParams.updateMask = updateMask.join(",");
+  }
+  const path = key.name.startsWith("/") ? key.name : `/${key.name}`;
+  const res = await client.patch<Key, OperationResult<Key> & { name: string }>(path, key, {
+    queryParams,
+  });
+
+  if (res.body.done && res.body.response) {
+    return res.body.response;
+  }
+
+  return await pollOperation<Key>({
+    apiOrigin: apiKeysOrigin(),
+    apiVersion: API_VERSION,
+    operationResourceName: res.body.name,
+  });
+}
+
+export interface ListKeysResponse {
+  keys?: Key[];
+  nextPageToken?: string;
+}
+
+/**
+ * Lists all API keys for a project, handling pagination.
+ * Ref: https://cloud.google.com/api-keys/docs/reference/rest/v2/projects.locations.keys/list
+ */
+export async function listKeys(projectId: string): Promise<Key[]> {
+  const parent = `projects/${projectId}/locations/global`;
+  let pageToken: string | undefined;
+  const keys: Key[] = [];
+
+  do {
+    const queryParams: Record<string, string> = pageToken ? { pageToken } : {};
+    const res = await client.get<ListKeysResponse>(`/${parent}/keys`, { queryParams });
+    if (res.body.keys) {
+      keys.push(...res.body.keys);
+    }
+    pageToken = res.body.nextPageToken;
+  } while (pageToken);
+
+  return keys;
+}
+
+/**
+ * Ensures a specific service is permitted in an API key's restrictions.
+ *
+ * - If the key is unrestricted (`apiTargets` is undefined or empty), no changes are made
+ *   because the key is already allowed to access all enabled services on the project.
+ * - If the key is restricted and already includes the service, no update is performed.
+ * - If the key is restricted and is missing the service, the service is appended to `apiTargets`
+ *   and the key is updated.
+ */
+export async function ensureServiceInKeyRestrictions(
+  key: Key | string,
+  service: string,
+): Promise<{ updated: boolean; key: Key }> {
+  const resolvedKey = typeof key === "string" ? await getKeyByString(key) : key;
+
+  if (!resolvedKey.restrictions?.apiTargets || resolvedKey.restrictions.apiTargets.length === 0) {
+    return { updated: false, key: resolvedKey };
+  }
+
+  const alreadyAllowed = resolvedKey.restrictions.apiTargets.some(
+    (target) => target.service === service,
+  );
+  if (alreadyAllowed) {
+    return { updated: false, key: resolvedKey };
+  }
+
+  const updatedRestrictions: Restrictions = {
+    ...resolvedKey.restrictions,
+    apiTargets: [...resolvedKey.restrictions.apiTargets, { service }],
+  };
+
+  const updatedKey = await updateKey(
+    {
+      ...resolvedKey,
+      restrictions: updatedRestrictions,
+    },
+    ["restrictions"],
+  );
+
+  return { updated: true, key: updatedKey };
+}
+
+/**
+ * Ensures a specific service is permitted across all restricted API keys in a project.
+ *
+ * - For keys that are unrestricted (`apiTargets` is undefined or empty), no changes are made
+ *   to avoid accidentally restricting them.
+ * - For keys that are restricted and missing the service, the service is appended to `apiTargets`.
+ */
+export async function ensureServiceInProjectKeyRestrictions(
+  projectId: string,
+  service: string,
+): Promise<{ updatedKeys: Key[]; unchangedKeys: Key[] }> {
+  const keys = await listKeys(projectId);
+  const updatedKeys: Key[] = [];
+  const unchangedKeys: Key[] = [];
+
+  for (const key of keys) {
+    const result = await ensureServiceInKeyRestrictions(key, service);
+    if (result.updated) {
+      updatedKeys.push(result.key);
+    } else {
+      unchangedKeys.push(result.key);
+    }
+  }
+
+  return { updatedKeys, unchangedKeys };
+}
+
+/**
+ * Updates restrictions across all API keys in a project using a custom updater function.
+ *
+ * The updater function receives the current `Restrictions` and `Key`. If it returns a new
+ * `Restrictions` object, the key is updated. If it returns undefined or null, the key is skipped.
+ */
+export async function updateProjectKeyRestrictions(
+  projectId: string,
+  updater: (restrictions: Restrictions, key: Key) => Restrictions | undefined | null,
+): Promise<{ updatedKeys: Key[]; unchangedKeys: Key[] }> {
+  const keys = await listKeys(projectId);
+  const updatedKeys: Key[] = [];
+  const unchangedKeys: Key[] = [];
+
+  for (const key of keys) {
+    const newRestrictions = updater(key.restrictions || {}, key);
+    if (newRestrictions) {
+      const updatedKey = await updateKey(
+        {
+          ...key,
+          restrictions: newRestrictions,
+        },
+        ["restrictions"],
+      );
+      updatedKeys.push(updatedKey);
+    } else {
+      unchangedKeys.push(key);
+    }
+  }
+
+  return { updatedKeys, unchangedKeys };
+}

--- a/src/gcp/apikeys.ts
+++ b/src/gcp/apikeys.ts
@@ -1,43 +1,43 @@
 import { apiKeysOrigin } from "../api";
 import { Client } from "../apiv2";
 import { FirebaseError, getErrStatus } from "../error";
-import { OperationResult, pollOperation } from "../operation-poller";
+import { LongRunningOperation, pollOperation } from "../operation-poller";
 
-export const API_VERSION = "v2";
+const API_VERSION = "v2";
 
-export const client = new Client({
+const client = new Client({
   urlPrefix: apiKeysOrigin(),
   auth: true,
   apiVersion: API_VERSION,
 });
 
-export interface ApiTarget {
+interface ApiTarget {
   service: string;
   methods?: string[];
 }
 
-export interface AndroidApplication {
+interface AndroidApplication {
   sha1Fingerprint: string;
   packageName: string;
 }
 
-export interface AndroidKeyRestrictions {
+interface AndroidKeyRestrictions {
   allowedApplications: AndroidApplication[];
 }
 
-export interface IosKeyRestrictions {
+interface IosKeyRestrictions {
   allowedBundleIds: string[];
 }
 
-export interface BrowserKeyRestrictions {
+interface BrowserKeyRestrictions {
   allowedReferrers: string[];
 }
 
-export interface ServerKeyRestrictions {
+interface ServerKeyRestrictions {
   allowedIps: string[];
 }
 
-export interface Restrictions {
+interface Restrictions {
   apiTargets?: ApiTarget[];
   browserKeyRestrictions?: BrowserKeyRestrictions;
   serverKeyRestrictions?: ServerKeyRestrictions;
@@ -45,40 +45,54 @@ export interface Restrictions {
   iosKeyRestrictions?: IosKeyRestrictions;
 }
 
-export interface Key {
+interface Key {
   name: string;
   displayName?: string;
+  keyString: string;
   restrictions?: Restrictions;
 }
 
-export interface LookupKeyResponse {
+interface LookupKeyResponse {
   name: string;
   parent: string;
   displayName?: string;
 }
 
-function getCredentialsConsoleUrl(projectId?: string): string {
-  return projectId
-    ? `https://console.cloud.google.com/apis/credentials?project=${projectId}`
-    : `https://console.cloud.google.com/apis/credentials`;
+/**
+ * Ensures that a specific service is allowed under the restrictions of the API key
+ * identified by the given API key string.
+ *
+ * If the API key is unrestricted, this is a no-op. If it is restricted and does not
+ * already allow the service, the service is added to the key's allowed API targets.
+ *
+ * @param apiKeyString The API key string (e.g. "AIzaSy...") to update.
+ * @param service The service to allow (e.g. "firebasetelemetry.googleapis.com").
+ */
+export async function updateAppApiKeyRestriction(
+  apiKeyString: string,
+  service: string,
+): Promise<void> {
+  const lookup = await lookupKeyResourceName(apiKeyString);
+  const key = await getKeyWithResourceName(lookup.name);
+  await ensureServiceInKeyRestrictions(key, service);
 }
 
 /**
  * Looks up the key resource name and parent for a given API key string.
  * Ref: https://cloud.google.com/api-keys/docs/reference/rest/v2/keys/lookupKey
  */
-export async function lookupKey(keyString: string): Promise<LookupKeyResponse> {
+async function lookupKeyResourceName(apiKeyString: string): Promise<LookupKeyResponse> {
   try {
     const res = await client.get<LookupKeyResponse>("/keys:lookupKey", {
-      queryParams: { keyString },
+      queryParams: { keyString: apiKeyString },
     });
     return res.body;
   } catch (err: unknown) {
     if (getErrStatus(err) === 403) {
       throw new FirebaseError(
         `Permission denied when looking up API key.\n\n` +
-        `To resolve this, ensure your account has the right permissions on the project in the Google Cloud Console:\n\n` +
-        `  ${getCredentialsConsoleUrl()}`,
+          `To resolve this, ensure your account has the right permissions on the project in the Google Cloud Console:\n\n` +
+          `  ${getCredentialsConsoleUrl()}`,
         { original: err instanceof Error ? err : undefined, status: 403 },
       );
     }
@@ -90,104 +104,16 @@ export async function lookupKey(keyString: string): Promise<LookupKeyResponse> {
  * Gets the details of an API key given its resource name.
  * Ref: https://cloud.google.com/api-keys/docs/reference/rest/v2/projects.locations.keys/get
  */
-export async function getKey(keyName: string): Promise<Key> {
-  const path = keyName.startsWith("/") ? keyName : `/${keyName}`;
+async function getKeyWithResourceName(keyResourceName: string): Promise<Key> {
   try {
-    const res = await client.get<Key>(path);
+    const res = await client.get<Key>(keyResourceName);
     return res.body;
   } catch (err: unknown) {
     if (getErrStatus(err) === 403) {
-      const projectId = extractProjectId(keyName.replace(/^\//, ""));
       throw new FirebaseError(
-        `Permission denied when retrieving API key ${keyName}.\n\n` +
-        `To resolve this, ensure your account has the right permissions on the project in the Google Cloud Console:\n\n` +
-        `  ${getCredentialsConsoleUrl(projectId)}`,
-        { original: err instanceof Error ? err : undefined, status: 403 },
-      );
-    }
-    throw err;
-  }
-}
-
-/**
- * Retrieves an API key's full resource by its key string.
- */
-export async function getKeyByString(keyString: string): Promise<Key> {
-  const lookup = await lookupKey(keyString);
-  return getKey(lookup.name);
-}
-
-/**
- * Updates the properties of an API key, tracking the long-running operation until completion.
- * Ref: https://cloud.google.com/api-keys/docs/reference/rest/v2/projects.locations.keys/patch
- */
-async function updateKey(key: Key, updateMask: string[] = ["restrictions"]): Promise<Key> {
-  const queryParams: Record<string, string> = {};
-  if (updateMask.length > 0) {
-    queryParams.updateMask = updateMask.join(",");
-  }
-  const path = key.name.startsWith("/") ? key.name : `/${key.name}`;
-
-  try {
-    const res = await client.patch<Key, OperationResult<Key> & { name: string }>(path, key, {
-      queryParams,
-    });
-
-    if (res.body.done && res.body.response) {
-      return res.body.response;
-    }
-
-    return await pollOperation<Key>({
-      apiOrigin: apiKeysOrigin(),
-      apiVersion: API_VERSION,
-      operationResourceName: res.body.name,
-    });
-  } catch (err: unknown) {
-    if (getErrStatus(err) === 403) {
-      const keyIdentifier = key.displayName ? `${key.displayName} (${key.name})` : key.name;
-      const projectId = extractProjectId(key.name.replace(/^\//, ""));
-      throw new FirebaseError(
-        `Permission denied when updating API key ${keyIdentifier}.\n\n` +
-        `To resolve this, ensure your account has the right permissions on the project in the Google Cloud Console:\n\n` +
-        `  ${getCredentialsConsoleUrl(projectId)}`,
-        { original: err instanceof Error ? err : undefined, status: 403 },
-      );
-    }
-    throw err;
-  }
-}
-
-export interface ListKeysResponse {
-  keys?: Key[];
-  nextPageToken?: string;
-}
-
-/**
- * Lists all API keys for a project, handling pagination.
- * Ref: https://cloud.google.com/api-keys/docs/reference/rest/v2/projects.locations.keys/list
- */
-export async function listKeys(projectId: string): Promise<Key[]> {
-  const parent = `projects/${projectId}/locations/global`;
-  let pageToken: string | undefined;
-  const keys: Key[] = [];
-
-  try {
-    do {
-      const queryParams: Record<string, string> = pageToken ? { pageToken } : {};
-      const res = await client.get<ListKeysResponse>(`/${parent}/keys`, { queryParams });
-      if (res.body.keys) {
-        keys.push(...res.body.keys);
-      }
-      pageToken = res.body.nextPageToken;
-    } while (pageToken);
-
-    return keys;
-  } catch (err: unknown) {
-    if (getErrStatus(err) === 403) {
-      throw new FirebaseError(
-        `Permission denied when listing API keys for project ${projectId}.\n\n` +
-        `To resolve this, ensure your account has the right permissions on the project in the Google Cloud Console:\n\n` +
-        `  ${getCredentialsConsoleUrl(projectId)}`,
+        `Permission denied when retrieving API key ${keyResourceName}.\n\n` +
+          `To resolve this, ensure your account has the right permissions on the project in the Google Cloud Console:\n\n` +
+          `  ${getCredentialsConsoleUrl()}`,
         { original: err instanceof Error ? err : undefined, status: 403 },
       );
     }
@@ -204,83 +130,61 @@ export async function listKeys(projectId: string): Promise<Key[]> {
  * - If the key is restricted and is missing the service, the service is appended to `apiTargets`
  *   and the key is updated.
  */
-export async function ensureServiceInKeyRestrictions(
-  key: Key | string,
-  service: string,
-): Promise<{ updated: boolean; key: Key }> {
-  const resolvedKey = typeof key === "string" ? await getKeyByString(key) : key;
-
-  if (!resolvedKey.restrictions?.apiTargets || resolvedKey.restrictions.apiTargets.length === 0) {
-    return { updated: false, key: resolvedKey };
+async function ensureServiceInKeyRestrictions(key: Key, service: string): Promise<void> {
+  if (!key.restrictions?.apiTargets || key.restrictions.apiTargets.length === 0) {
+    return;
   }
 
-  const alreadyAllowed = resolvedKey.restrictions.apiTargets.some(
-    (target) => target.service === service,
-  );
+  const alreadyAllowed = key.restrictions.apiTargets.some((target) => target.service === service);
   if (alreadyAllowed) {
-    return { updated: false, key: resolvedKey };
+    return;
   }
 
   const updatedRestrictions: Restrictions = {
-    ...resolvedKey.restrictions,
-    apiTargets: [...resolvedKey.restrictions.apiTargets, { service }],
+    ...key.restrictions,
+    apiTargets: [...key.restrictions.apiTargets, { service }],
   };
 
-  const updatedKey = await updateKey(
-    {
-      ...resolvedKey,
-      restrictions: updatedRestrictions,
-    },
-    ["restrictions"],
-  );
-
-  return { updated: true, key: updatedKey };
+  await updateKeyRestrictions({
+    ...key,
+    restrictions: updatedRestrictions,
+  });
 }
 
 /**
- * Ensures a specific service is permitted across all restricted API keys in a project.
- *
- * - For keys that are unrestricted (`apiTargets` is undefined or empty), no changes are made
- *   to avoid accidentally restricting them.
- * - For keys that are restricted and missing the service, the service is appended to `apiTargets`.
+ * Updates the properties of an API key, tracking the long-running operation until completion.
+ * Ref: https://cloud.google.com/api-keys/docs/reference/rest/v2/projects.locations.keys/patch
  */
-export async function updateAllApiKeysRestriction(
-  projectId: string,
-  service: string,
-): Promise<void> {
-  const keys = await listKeys(projectId);
-  await Promise.all(keys.map((key) => ensureServiceInKeyRestrictions(key, service)));
+async function updateKeyRestrictions(key: Key): Promise<void> {
+  const queryParams: Record<string, string> = { updateMask: "restrictions" };
+
+  try {
+    const res = await client.patch<Key, LongRunningOperation<Key>>(key.name, key, {
+      queryParams,
+    });
+
+    await pollOperation<Key>({
+      apiOrigin: apiKeysOrigin(),
+      apiVersion: API_VERSION,
+      operationResourceName: res.body.name,
+    });
+  } catch (err: unknown) {
+    if (getErrStatus(err) === 403) {
+      const keyIdentifier = key.displayName ? `${key.displayName} (${key.name})` : key.name;
+      throw new FirebaseError(
+        `Permission denied when updating API key ${keyIdentifier}.\n\n` +
+          `To resolve this, ensure your account has the right permissions on the project in the Google Cloud Console:\n\n` +
+          `  ${getCredentialsConsoleUrl()}`,
+        { original: err instanceof Error ? err : undefined, status: 403 },
+      );
+    }
+    throw err;
+  }
 }
 
 /**
- * Updates restrictions across all API keys in a project using a custom updater function.
- *
- * The updater function receives the current `Restrictions` and `Key`. If it returns a new
- * `Restrictions` object, the key is updated. If it returns undefined or null, the key is skipped.
- *
-export async function updateProjectKeyRestrictions(
-  projectId: string,
-  updater: (restrictions: Restrictions, key: Key) => Restrictions | undefined | null,
-): Promise<{ updatedKeys: Key[]; unchangedKeys: Key[] }> {
-  const keys = await listKeys(projectId);
-  const updatedKeys: Key[] = [];
-  const unchangedKeys: Key[] = [];
-
-  for (const key of keys) {
-    const newRestrictions = updater(key.restrictions || {}, key);
-    if (newRestrictions) {
-      const updatedKey = await updateKey(
-        {
-          ...key,
-          restrictions: newRestrictions,
-        },
-        ["restrictions"],
-      );
-      updatedKeys.push(updatedKey);
-    } else {
-      unchangedKeys.push(key);
-    }
-  }
-
-  return { updatedKeys, unchangedKeys };
-}*/
+ * Returns the URL to the Google Cloud Console credentials page.
+ */
+function getCredentialsConsoleUrl(): string {
+  return "https://console.cloud.google.com/apis/credentials";
+}

--- a/src/gcp/apikeys.ts
+++ b/src/gcp/apikeys.ts
@@ -62,7 +62,6 @@ interface LookupKeyResponse {
  *
  * If the API key is unrestricted, this is a no-op. If it is restricted and does not
  * already allow the service, the service is added to the key's allowed API targets.
- *
  * @param apiKeyString The API key string (e.g. "AIzaSy...") to update.
  * @param service The service to allow (e.g. "firebasetelemetry.googleapis.com").
  */
@@ -70,8 +69,8 @@ export async function updateAppApiKeyRestriction(
   apiKeyString: string,
   service: string,
 ): Promise<void> {
-  const lookup = await lookupKeyResourceName(apiKeyString);
-  const key = await getKey(lookup.name);
+  const keyResourceName = await lookupKeyResourceName(apiKeyString);
+  const key = await getKey(keyResourceName);
   await ensureServiceInKeyRestrictions(key, service);
 }
 
@@ -79,12 +78,12 @@ export async function updateAppApiKeyRestriction(
  * Looks up the key resource name for a given API key string.
  * Ref: https://cloud.google.com/api-keys/docs/reference/rest/v2/keys/lookupKey
  */
-async function lookupKeyResourceName(apiKeyString: string): Promise<LookupKeyResponse> {
+async function lookupKeyResourceName(apiKeyString: string): Promise<string> {
   try {
     const res = await client.get<LookupKeyResponse>("/keys:lookupKey", {
       queryParams: { keyString: apiKeyString },
     });
-    return res.body;
+    return res.body.name;
   } catch (err: unknown) {
     if (getErrStatus(err) === 403) {
       throw new FirebaseError(

--- a/src/gcp/apikeys.ts
+++ b/src/gcp/apikeys.ts
@@ -76,7 +76,7 @@ export async function updateAppApiKeyRestriction(
 }
 
 /**
- * Looks up the key resource name and parent for a given API key string.
+ * Looks up the key resource name for a given API key string.
  * Ref: https://cloud.google.com/api-keys/docs/reference/rest/v2/keys/lookupKey
  */
 async function lookupKeyResourceName(apiKeyString: string): Promise<LookupKeyResponse> {

--- a/src/gcp/apikeys.ts
+++ b/src/gcp/apikeys.ts
@@ -1,5 +1,6 @@
 import { apiKeysOrigin } from "../api";
 import { Client } from "../apiv2";
+import { FirebaseError, getErrStatus } from "../error";
 import { OperationResult, pollOperation } from "../operation-poller";
 
 export const API_VERSION = "v2";
@@ -46,14 +47,8 @@ export interface Restrictions {
 
 export interface Key {
   name: string;
-  uid?: string;
   displayName?: string;
-  keyString?: string;
   restrictions?: Restrictions;
-  etag?: string;
-  createTime?: string;
-  updateTime?: string;
-  deleteTime?: string;
 }
 
 export interface LookupKeyResponse {
@@ -62,15 +57,33 @@ export interface LookupKeyResponse {
   displayName?: string;
 }
 
+function getCredentialsConsoleUrl(projectId?: string): string {
+  return projectId
+    ? `https://console.cloud.google.com/apis/credentials?project=${projectId}`
+    : `https://console.cloud.google.com/apis/credentials`;
+}
+
 /**
  * Looks up the key resource name and parent for a given API key string.
  * Ref: https://cloud.google.com/api-keys/docs/reference/rest/v2/keys/lookupKey
  */
 export async function lookupKey(keyString: string): Promise<LookupKeyResponse> {
-  const res = await client.get<LookupKeyResponse>("/keys:lookupKey", {
-    queryParams: { keyString },
-  });
-  return res.body;
+  try {
+    const res = await client.get<LookupKeyResponse>("/keys:lookupKey", {
+      queryParams: { keyString },
+    });
+    return res.body;
+  } catch (err: unknown) {
+    if (getErrStatus(err) === 403) {
+      throw new FirebaseError(
+        `Permission denied when looking up API key.\n\n` +
+        `To resolve this, ensure your account has the right permissions on the project in the Google Cloud Console:\n\n` +
+        `  ${getCredentialsConsoleUrl()}`,
+        { original: err instanceof Error ? err : undefined, status: 403 },
+      );
+    }
+    throw err;
+  }
 }
 
 /**
@@ -79,8 +92,21 @@ export async function lookupKey(keyString: string): Promise<LookupKeyResponse> {
  */
 export async function getKey(keyName: string): Promise<Key> {
   const path = keyName.startsWith("/") ? keyName : `/${keyName}`;
-  const res = await client.get<Key>(path);
-  return res.body;
+  try {
+    const res = await client.get<Key>(path);
+    return res.body;
+  } catch (err: unknown) {
+    if (getErrStatus(err) === 403) {
+      const projectId = extractProjectId(keyName.replace(/^\//, ""));
+      throw new FirebaseError(
+        `Permission denied when retrieving API key ${keyName}.\n\n` +
+        `To resolve this, ensure your account has the right permissions on the project in the Google Cloud Console:\n\n` +
+        `  ${getCredentialsConsoleUrl(projectId)}`,
+        { original: err instanceof Error ? err : undefined, status: 403 },
+      );
+    }
+    throw err;
+  }
 }
 
 /**
@@ -95,25 +121,40 @@ export async function getKeyByString(keyString: string): Promise<Key> {
  * Updates the properties of an API key, tracking the long-running operation until completion.
  * Ref: https://cloud.google.com/api-keys/docs/reference/rest/v2/projects.locations.keys/patch
  */
-export async function updateKey(key: Key, updateMask: string[] = ["restrictions"]): Promise<Key> {
+async function updateKey(key: Key, updateMask: string[] = ["restrictions"]): Promise<Key> {
   const queryParams: Record<string, string> = {};
   if (updateMask.length > 0) {
     queryParams.updateMask = updateMask.join(",");
   }
   const path = key.name.startsWith("/") ? key.name : `/${key.name}`;
-  const res = await client.patch<Key, OperationResult<Key> & { name: string }>(path, key, {
-    queryParams,
-  });
 
-  if (res.body.done && res.body.response) {
-    return res.body.response;
+  try {
+    const res = await client.patch<Key, OperationResult<Key> & { name: string }>(path, key, {
+      queryParams,
+    });
+
+    if (res.body.done && res.body.response) {
+      return res.body.response;
+    }
+
+    return await pollOperation<Key>({
+      apiOrigin: apiKeysOrigin(),
+      apiVersion: API_VERSION,
+      operationResourceName: res.body.name,
+    });
+  } catch (err: unknown) {
+    if (getErrStatus(err) === 403) {
+      const keyIdentifier = key.displayName ? `${key.displayName} (${key.name})` : key.name;
+      const projectId = extractProjectId(key.name.replace(/^\//, ""));
+      throw new FirebaseError(
+        `Permission denied when updating API key ${keyIdentifier}.\n\n` +
+        `To resolve this, ensure your account has the right permissions on the project in the Google Cloud Console:\n\n` +
+        `  ${getCredentialsConsoleUrl(projectId)}`,
+        { original: err instanceof Error ? err : undefined, status: 403 },
+      );
+    }
+    throw err;
   }
-
-  return await pollOperation<Key>({
-    apiOrigin: apiKeysOrigin(),
-    apiVersion: API_VERSION,
-    operationResourceName: res.body.name,
-  });
 }
 
 export interface ListKeysResponse {
@@ -130,16 +171,28 @@ export async function listKeys(projectId: string): Promise<Key[]> {
   let pageToken: string | undefined;
   const keys: Key[] = [];
 
-  do {
-    const queryParams: Record<string, string> = pageToken ? { pageToken } : {};
-    const res = await client.get<ListKeysResponse>(`/${parent}/keys`, { queryParams });
-    if (res.body.keys) {
-      keys.push(...res.body.keys);
-    }
-    pageToken = res.body.nextPageToken;
-  } while (pageToken);
+  try {
+    do {
+      const queryParams: Record<string, string> = pageToken ? { pageToken } : {};
+      const res = await client.get<ListKeysResponse>(`/${parent}/keys`, { queryParams });
+      if (res.body.keys) {
+        keys.push(...res.body.keys);
+      }
+      pageToken = res.body.nextPageToken;
+    } while (pageToken);
 
-  return keys;
+    return keys;
+  } catch (err: unknown) {
+    if (getErrStatus(err) === 403) {
+      throw new FirebaseError(
+        `Permission denied when listing API keys for project ${projectId}.\n\n` +
+        `To resolve this, ensure your account has the right permissions on the project in the Google Cloud Console:\n\n` +
+        `  ${getCredentialsConsoleUrl(projectId)}`,
+        { original: err instanceof Error ? err : undefined, status: 403 },
+      );
+    }
+    throw err;
+  }
 }
 
 /**
@@ -191,24 +244,12 @@ export async function ensureServiceInKeyRestrictions(
  *   to avoid accidentally restricting them.
  * - For keys that are restricted and missing the service, the service is appended to `apiTargets`.
  */
-export async function ensureServiceInProjectKeyRestrictions(
+export async function updateAllApiKeysRestriction(
   projectId: string,
   service: string,
-): Promise<{ updatedKeys: Key[]; unchangedKeys: Key[] }> {
+): Promise<void> {
   const keys = await listKeys(projectId);
-  const updatedKeys: Key[] = [];
-  const unchangedKeys: Key[] = [];
-
-  for (const key of keys) {
-    const result = await ensureServiceInKeyRestrictions(key, service);
-    if (result.updated) {
-      updatedKeys.push(result.key);
-    } else {
-      unchangedKeys.push(result.key);
-    }
-  }
-
-  return { updatedKeys, unchangedKeys };
+  await Promise.all(keys.map((key) => ensureServiceInKeyRestrictions(key, service)));
 }
 
 /**
@@ -216,7 +257,7 @@ export async function ensureServiceInProjectKeyRestrictions(
  *
  * The updater function receives the current `Restrictions` and `Key`. If it returns a new
  * `Restrictions` object, the key is updated. If it returns undefined or null, the key is skipped.
- */
+ *
 export async function updateProjectKeyRestrictions(
   projectId: string,
   updater: (restrictions: Restrictions, key: Key) => Restrictions | undefined | null,
@@ -242,4 +283,4 @@ export async function updateProjectKeyRestrictions(
   }
 
   return { updatedKeys, unchangedKeys };
-}
+}*/

--- a/src/gcp/apikeys.ts
+++ b/src/gcp/apikeys.ts
@@ -13,47 +13,47 @@ const client = new Client({
 });
 
 interface ApiTarget {
-  service: string;
-  methods?: string[];
+  readonly service: string;
+  readonly methods?: readonly string[];
 }
 
 interface AndroidApplication {
-  sha1Fingerprint: string;
-  packageName: string;
+  readonly sha1Fingerprint: string;
+  readonly packageName: string;
 }
 
 interface AndroidKeyRestrictions {
-  allowedApplications: AndroidApplication[];
+  readonly allowedApplications: readonly AndroidApplication[];
 }
 
 interface IosKeyRestrictions {
-  allowedBundleIds: string[];
+  readonly allowedBundleIds: readonly string[];
 }
 
 interface BrowserKeyRestrictions {
-  allowedReferrers: string[];
+  readonly allowedReferrers: readonly string[];
 }
 
 interface ServerKeyRestrictions {
-  allowedIps: string[];
+  readonly allowedIps: readonly string[];
 }
 
 interface Restrictions {
-  apiTargets?: ApiTarget[];
-  browserKeyRestrictions?: BrowserKeyRestrictions;
-  serverKeyRestrictions?: ServerKeyRestrictions;
-  androidKeyRestrictions?: AndroidKeyRestrictions;
-  iosKeyRestrictions?: IosKeyRestrictions;
+  readonly apiTargets?: readonly ApiTarget[];
+  readonly browserKeyRestrictions?: BrowserKeyRestrictions;
+  readonly serverKeyRestrictions?: ServerKeyRestrictions;
+  readonly androidKeyRestrictions?: AndroidKeyRestrictions;
+  readonly iosKeyRestrictions?: IosKeyRestrictions;
 }
 
 export interface Key {
-  name: string;
-  displayName?: string;
-  restrictions?: Restrictions;
+  readonly name: string;
+  readonly displayName?: string;
+  readonly restrictions?: Restrictions;
 }
 
 interface LookupKeyResponse {
-  name: string;
+  readonly name: string;
 }
 
 /**
@@ -62,14 +62,13 @@ interface LookupKeyResponse {
  *
  * If the API key is unrestricted, this is a no-op. If it is restricted and does not
  * already allow the service, the service is added to the key's allowed API targets.
- * @param apiKeyString The API key string (e.g. "AIzaSy...") to update.
- * @param service The service to allow (e.g. "firebasetelemetry.googleapis.com").
  */
-export async function updateAppApiKeyRestriction(
-  apiKeyString: string,
-  service: string,
-): Promise<void> {
-  const keyResourceName = await lookupKeyResourceName(apiKeyString);
+export async function updateAppApiKeyRestriction(options: {
+  apiKey: string;
+  service: string;
+}): Promise<void> {
+  const { apiKey, service } = options;
+  const keyResourceName = await lookupKeyResourceName(apiKey);
   const key = await getKey(keyResourceName);
   await ensureServiceInKeyRestrictions(key, service);
 }

--- a/src/gcp/apikeys.ts
+++ b/src/gcp/apikeys.ts
@@ -4,6 +4,7 @@ import { FirebaseError, getErrStatus } from "../error";
 import { LongRunningOperation, pollOperation } from "../operation-poller";
 
 const API_VERSION = "v2";
+const CREDENTIALS_CONSOLE_URL = "https://console.cloud.google.com/apis/credentials";
 
 const client = new Client({
   urlPrefix: apiKeysOrigin(),
@@ -45,17 +46,14 @@ interface Restrictions {
   iosKeyRestrictions?: IosKeyRestrictions;
 }
 
-interface Key {
+export interface Key {
   name: string;
   displayName?: string;
-  keyString: string;
   restrictions?: Restrictions;
 }
 
 interface LookupKeyResponse {
   name: string;
-  parent: string;
-  displayName?: string;
 }
 
 /**
@@ -73,7 +71,7 @@ export async function updateAppApiKeyRestriction(
   service: string,
 ): Promise<void> {
   const lookup = await lookupKeyResourceName(apiKeyString);
-  const key = await getKeyWithResourceName(lookup.name);
+  const key = await getKey(lookup.name);
   await ensureServiceInKeyRestrictions(key, service);
 }
 
@@ -92,7 +90,7 @@ async function lookupKeyResourceName(apiKeyString: string): Promise<LookupKeyRes
       throw new FirebaseError(
         `Permission denied when looking up API key.\n\n` +
           `To resolve this, ensure your account has the right permissions on the project in the Google Cloud Console:\n\n` +
-          `  ${getCredentialsConsoleUrl()}`,
+          `  ${CREDENTIALS_CONSOLE_URL}`,
         { original: err instanceof Error ? err : undefined, status: 403 },
       );
     }
@@ -104,7 +102,7 @@ async function lookupKeyResourceName(apiKeyString: string): Promise<LookupKeyRes
  * Gets the details of an API key given its resource name.
  * Ref: https://cloud.google.com/api-keys/docs/reference/rest/v2/projects.locations.keys/get
  */
-async function getKeyWithResourceName(keyResourceName: string): Promise<Key> {
+async function getKey(keyResourceName: string): Promise<Key> {
   try {
     const res = await client.get<Key>(keyResourceName);
     return res.body;
@@ -113,7 +111,7 @@ async function getKeyWithResourceName(keyResourceName: string): Promise<Key> {
       throw new FirebaseError(
         `Permission denied when retrieving API key ${keyResourceName}.\n\n` +
           `To resolve this, ensure your account has the right permissions on the project in the Google Cloud Console:\n\n` +
-          `  ${getCredentialsConsoleUrl()}`,
+          `  ${CREDENTIALS_CONSOLE_URL}`,
         { original: err instanceof Error ? err : undefined, status: 403 },
       );
     }
@@ -123,23 +121,20 @@ async function getKeyWithResourceName(keyResourceName: string): Promise<Key> {
 
 /**
  * Ensures a specific service is permitted in an API key's restrictions.
- *
- * - If the key is unrestricted (`apiTargets` is undefined or empty), no changes are made
- *   because the key is already allowed to access all enabled services on the project.
- * - If the key is restricted and already includes the service, no update is performed.
- * - If the key is restricted and is missing the service, the service is appended to `apiTargets`
- *   and the key is updated.
  */
 async function ensureServiceInKeyRestrictions(key: Key, service: string): Promise<void> {
+  // If the key is unrestricted, no update is made
   if (!key.restrictions?.apiTargets || key.restrictions.apiTargets.length === 0) {
     return;
   }
 
+  // If the key is restricted and already includes the service, no update is made
   const alreadyAllowed = key.restrictions.apiTargets.some((target) => target.service === service);
   if (alreadyAllowed) {
     return;
   }
 
+  // If the key is restricted and is missing the service, key is updated
   const updatedRestrictions: Restrictions = {
     ...key.restrictions,
     apiTargets: [...key.restrictions.apiTargets, { service }],
@@ -174,17 +169,10 @@ async function updateKeyRestrictions(key: Key): Promise<void> {
       throw new FirebaseError(
         `Permission denied when updating API key ${keyIdentifier}.\n\n` +
           `To resolve this, ensure your account has the right permissions on the project in the Google Cloud Console:\n\n` +
-          `  ${getCredentialsConsoleUrl()}`,
+          `  ${CREDENTIALS_CONSOLE_URL}`,
         { original: err instanceof Error ? err : undefined, status: 403 },
       );
     }
     throw err;
   }
-}
-
-/**
- * Returns the URL to the Google Cloud Console credentials page.
- */
-function getCredentialsConsoleUrl(): string {
-  return "https://console.cloud.google.com/apis/credentials";
 }


### PR DESCRIPTION
- updated crashlytics cli onboarding command to enable API key restriction for telemetry API
- created gcp tool to update api key restriction with its key string
