### PR TITLE
fix(auth): use 127.0.0.1 for OAuth loopback and surface --no-localhost hint

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -287,7 +287,7 @@ function getCallbackUrl(port?: number): string {
   if (typeof port === "undefined") {
     return "urn:ietf:wg:oauth:2.0:oob";
   }
-  return `http://localhost:${port}`;
+  return `http://127.0.0.1:${port}`;
 }
 
 function queryParamString(args: { [key: string]: string | undefined }) {
@@ -632,7 +632,7 @@ async function loginWithLocalhost<ResultType>(
       return;
     });
 
-    server.listen(port, () => {
+    server.listen(port, "127.0.0.1", () => {
       logger.info();
       logger.info("Visit this URL on this device to log in:");
       logger.info(clc.bold(clc.underline(authUrl)));
@@ -640,6 +640,18 @@ async function loginWithLocalhost<ResultType>(
       logger.info("Waiting for authentication...");
 
       open(authUrl);
+
+      setTimeout(() => {
+        if (server.listening) {
+          logger.info();
+          logger.info(
+            "Having trouble? Try " +
+              clc.bold("firebase login --no-localhost") +
+              " or " +
+              clc.bold("firebase login:ci"),
+          );
+        }
+      }, 30_000);
     });
 
     server.on("error", (err) => {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -641,7 +641,7 @@ async function loginWithLocalhost<ResultType>(
 
       open(authUrl);
 
-      setTimeout(() => {
+      const timeoutId = setTimeout(() => {
         if (server.listening) {
           logger.info();
           logger.info(
@@ -652,6 +652,10 @@ async function loginWithLocalhost<ResultType>(
           );
         }
       }, 30_000);
+
+      server.on("close", () => {
+        clearTimeout(timeoutId);
+      });
     });
 
     server.on("error", (err) => {


### PR DESCRIPTION
## Summary

Fixes #10750

On dual-stack Windows and corp-managed machines, `localhost` can resolve to `::1` or a hosts-file override while the HTTP server binds to `0.0.0.0`, causing the OAuth callback to silently fail and the CLI to hang indefinitely on "Waiting for authentication...".

### Changes

**`src/auth.ts`:**

1. **`getCallbackUrl()`**: Changed redirect URI from `http://localhost:<port>` to `http://127.0.0.1:<port>`, per [Google's OAuth 2.0 for Native Apps guidance](https://developers.google.com/identity/protocols/oauth2/native-app#request-parameter-redirect_uri) which explicitly recommends `127.0.0.1` over `localhost` to avoid resolver ambiguity.

2. **`loginWithLocalhost()`**: Bind the HTTP server to `127.0.0.1` explicitly instead of all interfaces, ensuring the listener and redirect URI agree on the address.

3. **Timeout hint**: After 30 seconds with no callback, print a message pointing users to `firebase login --no-localhost` and `firebase login:ci`. Today the CLI hangs silently — this gives corp/VPN users an actionable next step.

## Test plan

- [x] `getCallbackUrl(3000)` returns `http://127.0.0.1:3000`
- [x] Server binds to `127.0.0.1` only (not `0.0.0.0` or `::`)
- [x] After 30s of no callback, hint is printed
- [x] Hint is not printed if auth succeeds within 30s (server stops listening)

🤖 Generated with [Claude Code](https://claude.com/claude-code)