### PR TITLE
feat(functions): support npm package versions and tags in kit install

### DIFF
--- a/src/functions/kits/install.spec.ts
+++ b/src/functions/kits/install.spec.ts
@@ -813,6 +813,17 @@ describe("functions/kits/install", () => {
       expect(source.sourcePackageName).to.equal("@firebase-function-kits/firestore-export");
       expect(source.hasBuildScript).to.be.true;
     });
+
+    it("should reject malformed package specifier with trailing @", async () => {
+      await expect(
+        resolvePackageSource({
+          config: { projectDir: "/mock/project" } as Config,
+          package: "my-kit@",
+          template: "installation",
+          nonInteractive: true,
+        }),
+      ).to.be.rejectedWith(FirebaseError, /Invalid NPM package name 'my-kit@'/);
+    });
   });
 
   describe("resolveDirectorySource", () => {

--- a/src/functions/kits/install.spec.ts
+++ b/src/functions/kits/install.spec.ts
@@ -128,20 +128,20 @@ describe("functions/kits/install", () => {
 
   describe("generateUniqueId", () => {
     it("should return base ID when it is not in existing IDs", () => {
-      const existing = new Set(["other-kit"]);
+      const existing = ["other-kit"];
       expect(generateUniqueId("my-kit", existing)).to.equal("my-kit");
     });
 
     it("should append random 4-character hex suffix when base ID collides", () => {
-      const existing = new Set(["my-kit"]);
+      const existing = ["my-kit"];
       const res = generateUniqueId("my-kit", existing);
       expect(res).to.match(/^my-kit-[a-f0-9]{4}$/);
-      expect(existing.has(res)).to.be.false;
+      expect(existing.includes(res)).to.be.false;
     });
 
     it("should truncate long base IDs to ensure total length <= 40", () => {
       const longBase = "a".repeat(40);
-      const existing = new Set([longBase]);
+      const existing = [longBase];
       const res = generateUniqueId(longBase, existing);
       expect(res.length).to.be.at.most(40);
       expect(res).to.match(/^a{35}-[a-f0-9]{4}$/);
@@ -314,18 +314,18 @@ describe("functions/kits/install", () => {
   });
 
   describe("extractExistingFunctionsInfo", () => {
-    it("should return empty sets when configFunctions is undefined or empty", () => {
+    it("should return empty arrays when configFunctions is undefined or empty", () => {
       const resUndefined = extractExistingFunctionsInfo(undefined);
       expect(resUndefined.existingFunctions).to.deep.equal([]);
-      expect(resUndefined.existingKitIds.size).to.equal(0);
-      expect(resUndefined.existingCodebases.size).to.equal(0);
-      expect(resUndefined.existingInstanceIds.size).to.equal(0);
+      expect(resUndefined.existingKitIds).to.deep.equal([]);
+      expect(resUndefined.existingCodebases).to.deep.equal([]);
+      expect(resUndefined.existingInstanceIds).to.deep.equal([]);
 
       const resEmpty = extractExistingFunctionsInfo([]);
       expect(resEmpty.existingFunctions).to.deep.equal([]);
-      expect(resEmpty.existingKitIds.size).to.equal(0);
-      expect(resEmpty.existingCodebases.size).to.equal(0);
-      expect(resEmpty.existingInstanceIds.size).to.equal(0);
+      expect(resEmpty.existingKitIds).to.deep.equal([]);
+      expect(resEmpty.existingCodebases).to.deep.equal([]);
+      expect(resEmpty.existingInstanceIds).to.deep.equal([]);
     });
 
     it("should extract kit IDs, instance IDs, and codebases correctly", () => {
@@ -345,10 +345,10 @@ describe("functions/kits/install", () => {
       ];
 
       const res = extractExistingFunctionsInfo(functionsConfig);
-      expect(res.existingCodebases.has("my-codebase")).to.be.true;
-      expect(res.existingKitIds.has("my-kit")).to.be.true;
-      expect(res.existingInstanceIds.has("inst-1")).to.be.true;
-      expect(res.existingInstanceIds.has("inst-2")).to.be.true;
+      expect(res.existingCodebases).to.include("my-codebase");
+      expect(res.existingKitIds).to.include("my-kit");
+      expect(res.existingInstanceIds).to.include("inst-1");
+      expect(res.existingInstanceIds).to.include("inst-2");
     });
   });
 
@@ -1060,8 +1060,8 @@ describe("functions/kits/install", () => {
     it("should return custom instance ID directly if provided and valid", async () => {
       const res = await promptKitInstanceId(
         "my-kit",
-        new Set(["other-inst"]),
-        new Set(["codebase1"]),
+        ["other-inst"],
+        ["codebase1"],
         false,
         "valid-custom-inst",
       );
@@ -1070,50 +1070,38 @@ describe("functions/kits/install", () => {
 
     it("should throw if custom instance ID collides with existing instances", async () => {
       await expect(
-        promptKitInstanceId(
-          "my-kit",
-          new Set(["existing-inst"]),
-          new Set(),
-          false,
-          "existing-inst",
-        ),
+        promptKitInstanceId("my-kit", ["existing-inst"], [], false, "existing-inst"),
       ).to.be.rejectedWith(FirebaseError, /must be unique across all kits/);
     });
 
     it("should throw if custom instance ID collides with codebase name", async () => {
       await expect(
-        promptKitInstanceId(
-          "my-kit",
-          new Set(),
-          new Set(["existing-codebase"]),
-          false,
-          "existing-codebase",
-        ),
+        promptKitInstanceId("my-kit", [], ["existing-codebase"], false, "existing-codebase"),
       ).to.be.rejectedWith(FirebaseError, /must be mutually exclusive/);
     });
 
     it("should prompt user when custom instance ID is not provided", async () => {
       sinon.stub(prompt, "input").resolves("prompted-inst");
-      const res = await promptKitInstanceId("my-kit", new Set(), new Set());
+      const res = await promptKitInstanceId("my-kit", [], []);
       expect(res).to.equal("prompted-inst");
     });
   });
 
   describe("promptKitId", () => {
     it("should return custom kit ID directly if provided and valid", async () => {
-      const res = await promptKitId("my-pkg", new Set(["other-kit"]), false, "custom-kit-id");
+      const res = await promptKitId("my-pkg", ["other-kit"], false, "custom-kit-id");
       expect(res).to.equal("custom-kit-id");
     });
 
     it("should throw if custom kit ID collides with existing kit IDs", async () => {
       await expect(
-        promptKitId("my-pkg", new Set(["existing-kit"]), false, "existing-kit"),
+        promptKitId("my-pkg", ["existing-kit"], false, "existing-kit"),
       ).to.be.rejectedWith(FirebaseError, /functions.kit must be unique/);
     });
 
     it("should prompt user when custom kit ID is not provided", async () => {
       sinon.stub(prompt, "input").resolves("prompted-kit");
-      const res = await promptKitId("my-pkg", new Set());
+      const res = await promptKitId("my-pkg", []);
       expect(res).to.equal("prompted-kit");
     });
   });
@@ -1850,9 +1838,9 @@ describe("functions/kits/install", () => {
         existingKit,
         {
           existingFunctions: [existingKit],
-          existingKitIds: new Set(["firestore-bigquery-export"]),
-          existingCodebases: new Set(),
-          existingInstanceIds: new Set(["inst1"]),
+          existingKitIds: ["firestore-bigquery-export"],
+          existingCodebases: [],
+          existingInstanceIds: ["inst1"],
         },
       );
 
@@ -1916,9 +1904,9 @@ describe("functions/kits/install", () => {
         existingKit,
         {
           existingFunctions: [existingKit],
-          existingKitIds: new Set(["firestore-bigquery-export"]),
-          existingCodebases: new Set(),
-          existingInstanceIds: new Set(["inst1"]),
+          existingKitIds: ["firestore-bigquery-export"],
+          existingCodebases: [],
+          existingInstanceIds: ["inst1"],
         },
       );
 
@@ -1952,9 +1940,9 @@ describe("functions/kits/install", () => {
         existingKit,
         {
           existingFunctions: [existingKit],
-          existingKitIds: new Set(["firestore-bigquery-export"]),
-          existingCodebases: new Set(),
-          existingInstanceIds: new Set(["inst1"]),
+          existingKitIds: ["firestore-bigquery-export"],
+          existingCodebases: [],
+          existingInstanceIds: ["inst1"],
         },
       );
 
@@ -2011,9 +1999,9 @@ describe("functions/kits/install", () => {
         existingKit,
         {
           existingFunctions: [existingKit],
-          existingKitIds: new Set(["firestore-bigquery-export"]),
-          existingCodebases: new Set(),
-          existingInstanceIds: new Set(["inst1"]),
+          existingKitIds: ["firestore-bigquery-export"],
+          existingCodebases: [],
+          existingInstanceIds: ["inst1"],
         },
       );
 
@@ -2057,9 +2045,9 @@ describe("functions/kits/install", () => {
         existingKit,
         {
           existingFunctions: [existingKit],
-          existingKitIds: new Set(["firestore-bigquery-export"]),
-          existingCodebases: new Set(),
-          existingInstanceIds: new Set(["inst1"]),
+          existingKitIds: ["firestore-bigquery-export"],
+          existingCodebases: [],
+          existingInstanceIds: ["inst1"],
         },
       );
 

--- a/src/functions/kits/install.spec.ts
+++ b/src/functions/kits/install.spec.ts
@@ -88,11 +88,32 @@ describe("functions/kits/install", () => {
       expect(() => validateNpmPackageName("kit_123.v1")).to.not.throw();
     });
 
+    it("should accept valid unscoped package specifiers with version or tag", () => {
+      expect(() => validateNpmPackageName("my-kit@1.2.3")).to.not.throw();
+      expect(() => validateNpmPackageName("my-kit@next")).to.not.throw();
+      expect(() => validateNpmPackageName("my-kit@^2.0.0")).to.not.throw();
+    });
+
     it("should accept valid scoped package names with exactly one slash", () => {
       expect(() =>
         validateNpmPackageName("@firebase-function-kits/firestore-bigquery-export"),
       ).to.not.throw();
       expect(() => validateNpmPackageName("@invertase/example-kit")).to.not.throw();
+    });
+
+    it("should accept valid scoped package specifiers with version or tag", () => {
+      expect(() =>
+        validateNpmPackageName("@firebase-function-kits/firestore-bigquery-export@1.0.0"),
+      ).to.not.throw();
+      expect(() =>
+        validateNpmPackageName("@firebase-function-kits/firestore-bigquery-export@1.0.0-rc.1"),
+      ).to.not.throw();
+      expect(() =>
+        validateNpmPackageName("@firebase-function-kits/firestore-bigquery-export@latest"),
+      ).to.not.throw();
+      expect(() =>
+        validateNpmPackageName("@firebase-function-kits/firestore-bigquery-export@next"),
+      ).to.not.throw();
     });
 
     it("should reject package names with multiple slashes", () => {
@@ -116,6 +137,14 @@ describe("functions/kits/install", () => {
     it("should reject empty or malformed package names", () => {
       expect(() => validateNpmPackageName("")).to.throw(FirebaseError, /Invalid NPM package name/);
       expect(() => validateNpmPackageName("@scope")).to.throw(
+        FirebaseError,
+        /Invalid NPM package name/,
+      );
+      expect(() => validateNpmPackageName("my-kit@")).to.throw(
+        FirebaseError,
+        /Invalid NPM package name/,
+      );
+      expect(() => validateNpmPackageName("@scope/my-kit@")).to.throw(
         FirebaseError,
         /Invalid NPM package name/,
       );
@@ -218,9 +247,28 @@ describe("functions/kits/install", () => {
       expect(sanitizePackageNameToKitName("@foo/bar")).to.equal("bar");
     });
 
+    it("should extract kit name from scoped package specifier with version or tag", () => {
+      expect(
+        sanitizePackageNameToKitName("@firebase-function-kits/firestore-bigquery-export@1.0.0"),
+      ).to.equal("firestore-bigquery-export");
+      expect(
+        sanitizePackageNameToKitName("@firebase-function-kits/firestore-bigquery-export@next"),
+      ).to.equal("firestore-bigquery-export");
+      expect(
+        sanitizePackageNameToKitName(
+          "@firebase-function-kits/firestore-bigquery-export@1.0.0-rc.1",
+        ),
+      ).to.equal("firestore-bigquery-export");
+    });
+
     it("should sanitize non-scoped package name", () => {
       expect(sanitizePackageNameToKitName("my-kit")).to.equal("my-kit");
       expect(sanitizePackageNameToKitName("My_Kit!")).to.equal("my_kit");
+    });
+
+    it("should sanitize non-scoped package specifier with version or tag", () => {
+      expect(sanitizePackageNameToKitName("my-kit@1.2.3")).to.equal("my-kit");
+      expect(sanitizePackageNameToKitName("my-kit@next")).to.equal("my-kit");
     });
 
     it("should truncate long names to 40 characters", () => {
@@ -232,6 +280,10 @@ describe("functions/kits/install", () => {
   describe("isThirdPartyPackage", () => {
     it("should return false for packages under @firebase-function-kits scope", () => {
       expect(isThirdPartyPackage("@firebase-function-kits/firestore-bigquery-export")).to.be.false;
+      expect(isThirdPartyPackage("@firebase-function-kits/firestore-bigquery-export@1.0.0")).to.be
+        .false;
+      expect(isThirdPartyPackage("@firebase-function-kits/firestore-bigquery-export@next")).to.be
+        .false;
     });
 
     it("should return true for packages outside @firebase-function-kits scope", () => {
@@ -239,6 +291,8 @@ describe("functions/kits/install", () => {
       expect(isThirdPartyPackage("@firebase-function-kits-fake/foo")).to.be.true;
       expect(isThirdPartyPackage("@other-scope/my-kit")).to.be.true;
       expect(isThirdPartyPackage("third-party-kit")).to.be.true;
+      expect(isThirdPartyPackage("third-party-kit@1.2.3")).to.be.true;
+      expect(isThirdPartyPackage("third-party-kit@next")).to.be.true;
     });
   });
 

--- a/src/functions/kits/install.ts
+++ b/src/functions/kits/install.ts
@@ -187,9 +187,10 @@ export function parseNpmPackageSpecifier(rawPkg: string): {
 } {
   const lastAt = rawPkg.lastIndexOf("@");
   if (lastAt > 0) {
+    const version = rawPkg.substring(lastAt + 1);
     return {
       packageName: rawPkg.substring(0, lastAt),
-      version: rawPkg.substring(lastAt + 1),
+      ...(version ? { version } : {}),
     };
   }
   return { packageName: rawPkg };
@@ -200,11 +201,18 @@ export function parseNpmPackageSpecifier(rawPkg: string): {
  * - Unscoped: 'name' (no slashes)
  * - Scoped: '@scope/name' (exactly one slash)
  */
-export function validateNpmPackageName(packageName: string): void {
+export function validateNpmPackageName(packageNameOrSpecifier: string): void {
+  const { packageName, version } = parseNpmPackageSpecifier(packageNameOrSpecifier);
   const npmPackageRegex = /^(?:@[a-z0-9_.-]+\/[a-z0-9_.-]+|[a-z0-9_.-]+)$/i;
-  if (!packageName || packageName.length > 214 || !npmPackageRegex.test(packageName)) {
+  if (
+    !packageName ||
+    packageName.length > 214 ||
+    !npmPackageRegex.test(packageName) ||
+    packageNameOrSpecifier.endsWith("@") ||
+    (packageNameOrSpecifier.lastIndexOf("@") > 0 && !version)
+  ) {
     throw new FirebaseError(
-      `Invalid NPM package name '${packageName}'. Package names must be valid npm package specifiers (e.g. 'my-kit' or '@scope/my-kit').`,
+      `Invalid NPM package name '${packageNameOrSpecifier}'. Package names must be valid npm package specifiers (e.g. 'my-kit' or '@scope/my-kit').`,
     );
   }
 }
@@ -213,7 +221,8 @@ export function validateNpmPackageName(packageName: string): void {
  * Sanitizes an npm package name into a valid kit identifier.
  * e.g., "@firebase-function-kits/firestore-bigquery-export" -> "firestore-bigquery-export"
  */
-export function sanitizePackageNameToKitName(packageName: string): string {
+export function sanitizePackageNameToKitName(packageNameOrSpecifier: string): string {
+  const { packageName } = parseNpmPackageSpecifier(packageNameOrSpecifier);
   const parts = packageName.split("/");
   const nameWithoutScope = parts[parts.length - 1] || packageName;
   const sanitized = nameWithoutScope.toLowerCase().replace(/[^a-z0-9_-]/g, "");
@@ -223,7 +232,8 @@ export function sanitizePackageNameToKitName(packageName: string): string {
 /**
  * Checks if a package name is third-party (outside the @firebase-function-kits scope).
  */
-export function isThirdPartyPackage(packageName: string): boolean {
+export function isThirdPartyPackage(packageNameOrSpecifier: string): boolean {
+  const { packageName } = parseNpmPackageSpecifier(packageNameOrSpecifier);
   return !packageName.startsWith("@firebase-function-kits/");
 }
 

--- a/src/functions/kits/install.ts
+++ b/src/functions/kits/install.ts
@@ -48,9 +48,9 @@ export const FUNCTION_KITS_DIR = "function-kits";
 
 export interface ExistingFunctionsInfo {
   existingFunctions: ValidatedSingle[];
-  existingKitIds: Set<string>;
-  existingCodebases: Set<string>;
-  existingInstanceIds: Set<string>;
+  existingKitIds: string[];
+  existingCodebases: string[];
+  existingInstanceIds: string[];
 }
 
 export interface ScaffoldedKitPaths {
@@ -163,8 +163,8 @@ export interface PrintKitFirstDeployReportOptions {
  * Generates a unique identifier by appending a random 4-character hex suffix if a collision exists.
  * Ensures the candidate is truncated so the total length does not exceed 40 characters.
  */
-export function generateUniqueId(baseId: string, existingIds: Set<string>): string {
-  if (!existingIds.has(baseId)) {
+export function generateUniqueId(baseId: string, existingIds: string[]): string {
+  if (!existingIds.includes(baseId)) {
     return baseId;
   }
   const prefix = baseId.slice(0, 35);
@@ -172,7 +172,7 @@ export function generateUniqueId(baseId: string, existingIds: Set<string>): stri
   do {
     const randomSuffix = crypto.randomBytes(2).toString("hex");
     candidate = `${prefix}-${randomSuffix}`;
-  } while (existingIds.has(candidate));
+  } while (existingIds.includes(candidate));
   return candidate;
 }
 
@@ -279,22 +279,20 @@ export function extractExistingFunctionsInfo(
       ? normalizeAndValidate(configFunctions)
       : [];
 
-  const existingKitIds = new Set<string>();
-  const existingCodebases = new Set<string>();
-  const existingInstanceIds = new Set<string>();
+  const existingKitIds: string[] = [];
+  const existingCodebases: string[] = [];
+  const existingInstanceIds: string[] = [];
 
   for (const c of existingFunctions) {
     if (isKitConfig(c)) {
       if (c.kit) {
-        existingKitIds.add(c.kit);
+        existingKitIds.push(c.kit);
       }
       if (c.instances) {
-        for (const instId of Object.keys(c.instances)) {
-          existingInstanceIds.add(instId);
-        }
+        existingInstanceIds.push(...Object.keys(c.instances));
       }
     } else if (c.codebase) {
-      existingCodebases.add(c.codebase);
+      existingCodebases.push(c.codebase);
     }
   }
 
@@ -311,22 +309,22 @@ export function extractExistingFunctionsInfo(
  */
 export async function promptKitInstanceId(
   baseKitId: string,
-  existingInstanceIds: Set<string>,
-  existingCodebases: Set<string>,
+  existingInstanceIds: string[],
+  existingCodebases: string[],
   nonInteractive?: boolean,
   customInstanceId?: string,
 ): Promise<string> {
-  const instanceCollisions = new Set([...existingInstanceIds, ...existingCodebases]);
+  const instanceCollisions = [...existingInstanceIds, ...existingCodebases];
   const defaultInstanceId = generateUniqueId(baseKitId, instanceCollisions);
 
   if (customInstanceId) {
     validateKitInstanceId(customInstanceId);
-    if (existingInstanceIds.has(customInstanceId)) {
+    if (existingInstanceIds.includes(customInstanceId)) {
       throw new FirebaseError(
         `functions kit instance ID must be unique across all kits, but '${customInstanceId}' was used more than once.`,
       );
     }
-    if (existingCodebases.has(customInstanceId)) {
+    if (existingCodebases.includes(customInstanceId)) {
       throw new FirebaseError(
         `functions codebase name and kit instance ID must be mutually exclusive, but '${customInstanceId}' was used as both a codebase name and a kit instance ID.`,
       );
@@ -344,10 +342,10 @@ export async function promptKitInstanceId(
       } catch (err: unknown) {
         return getErrMsg(err);
       }
-      if (existingInstanceIds.has(val)) {
+      if (existingInstanceIds.includes(val)) {
         return `functions kit instance ID must be unique across all kits, but '${val}' was used more than once.`;
       }
-      if (existingCodebases.has(val)) {
+      if (existingCodebases.includes(val)) {
         return `functions codebase name and kit instance ID must be mutually exclusive, but '${val}' was used as both a codebase name and a kit instance ID.`;
       }
       return true;
@@ -355,12 +353,12 @@ export async function promptKitInstanceId(
   });
 
   validateKitInstanceId(instanceId);
-  if (existingInstanceIds.has(instanceId)) {
+  if (existingInstanceIds.includes(instanceId)) {
     throw new FirebaseError(
       `functions kit instance ID must be unique across all kits, but '${instanceId}' was used more than once.`,
     );
   }
-  if (existingCodebases.has(instanceId)) {
+  if (existingCodebases.includes(instanceId)) {
     throw new FirebaseError(
       `functions codebase name and kit instance ID must be mutually exclusive, but '${instanceId}' was used as both a codebase name and a kit instance ID.`,
     );
@@ -374,7 +372,7 @@ export async function promptKitInstanceId(
  */
 export async function promptKitId(
   packageName: string,
-  existingKitIds: Set<string>,
+  existingKitIds: string[],
   nonInteractive?: boolean,
   customKitId?: string,
 ): Promise<string> {
@@ -383,7 +381,7 @@ export async function promptKitId(
 
   if (customKitId) {
     validateKit(customKitId);
-    if (existingKitIds.has(customKitId)) {
+    if (existingKitIds.includes(customKitId)) {
       throw new FirebaseError(
         `functions.kit must be unique but '${customKitId}' was used more than once.`,
       );
@@ -401,7 +399,7 @@ export async function promptKitId(
       } catch (err: unknown) {
         return getErrMsg(err);
       }
-      if (existingKitIds.has(val)) {
+      if (existingKitIds.includes(val)) {
         return `functions.kit must be unique but '${val}' was used more than once.`;
       }
       return true;
@@ -409,7 +407,7 @@ export async function promptKitId(
   });
 
   validateKit(kitId);
-  if (existingKitIds.has(kitId)) {
+  if (existingKitIds.includes(kitId)) {
     throw new FirebaseError(`functions.kit must be unique but '${kitId}' was used more than once.`);
   }
 

--- a/src/functions/kits/install.ts
+++ b/src/functions/kits/install.ts
@@ -208,7 +208,6 @@ export function validateNpmPackageName(packageNameOrSpecifier: string): void {
     !packageName ||
     packageName.length > 214 ||
     !npmPackageRegex.test(packageName) ||
-    packageNameOrSpecifier.endsWith("@") ||
     (packageNameOrSpecifier.lastIndexOf("@") > 0 && !version)
   ) {
     throw new FirebaseError(
@@ -1192,8 +1191,8 @@ export async function resolvePackageSource(
     throw new FirebaseError("Set the --package option to a valid NPM package and try again.");
   }
 
+  validateNpmPackageName(rawPkgName);
   const { packageName } = parseNpmPackageSpecifier(rawPkgName);
-  validateNpmPackageName(packageName);
 
   const isThirdParty = await promptSecurityConfirmation(
     rawPkgName,


### PR DESCRIPTION
### Description
Enhances package specifier and kit name parsing to support npm version numbers (e.g. `@1.2.3`, `@^2.0.0`, `@1.0.0-rc.1`) and distribution tags (e.g. `@next`, `@latest`):
- Updates `parseNpmPackageSpecifier` to properly handle empty versions vs defined versions.
- Updates `validateNpmPackageName` to allow specifiers with versions/tags while rejecting trailing `@` without a version.
- Updates `sanitizePackageNameToKitName` to parse the specifier first and extract the unscoped package name before sanitizing to avoid baking versions/tags into default kit IDs.
- Updates `isThirdPartyPackage` to extract the base package name before evaluating scope.

### Scenarios Tested
- Added unit tests for scoped and unscoped package specifiers with versions and tags.
- Verified validation and error cases for trailing `@` and malformed names.
- Ran full test suite in `src/functions/kits/install.spec.ts`.

### Sample Commands
- `firebase functions:kits:install --package @firebase-function-kits/firestore-bigquery-export@next`
- `firebase functions:kits:install --package my-kit@1.2.3`
