### PR TITLE
fix(extensions): support optional source on extension instances and add ensureInstanceSpec

### DIFF
--- a/src/extensions/export.spec.ts
+++ b/src/extensions/export.spec.ts
@@ -421,6 +421,12 @@ describe("ensureInstanceSpec", () => {
     const res = await ensureInstanceSpec(instance);
     expect(res.config?.source?.spec?.name).to.equal("firestore-send-email");
     expect(res.config?.source?.spec?.params).to.have.length(1);
+    expect(res.config?.source?.name).to.equal(
+      "publishers/firebase/extensions/firestore-send-email/versions/0.1.35",
+    );
+    expect(res.config?.source?.packageUri).to.equal("https://example.com/download");
+    expect(res.config?.source?.hash).to.equal("hash123");
+    expect(res.config?.source?.state).to.equal("ACTIVE");
   });
 
   it("should fetch spec on demand if extensionRef is on instance directly", async () => {
@@ -464,5 +470,31 @@ describe("ensureInstanceSpec", () => {
     const res = await ensureInstanceSpec(instance);
     expect(res.config?.source?.spec?.name).to.equal("firestore-send-email");
     expect(res.config?.source?.spec?.params).to.have.length(1);
+    expect(res.config?.source?.name).to.equal(
+      "publishers/firebase/extensions/firestore-send-email/versions/0.1.35",
+    );
+  });
+
+  it("should let getExtensionVersion errors bubble up", async () => {
+    const instance: ExtensionInstance = {
+      name: "projects/123/instances/ext1",
+      createTime: "",
+      updateTime: "",
+      state: "ACTIVE",
+      serviceAccountEmail: "",
+      extensionRef: "firebase/firestore-send-email",
+      extensionVersion: "0.1.35",
+      config: {
+        name: "",
+        createTime: "",
+        params: {},
+        systemParams: {},
+      },
+    };
+
+    const networkErr = new Error("Network failure");
+    sandbox.stub(publisherApi, "getExtensionVersion").rejects(networkErr);
+
+    await expect(ensureInstanceSpec(instance)).to.be.rejectedWith(networkErr);
   });
 });

--- a/src/extensions/export.spec.ts
+++ b/src/extensions/export.spec.ts
@@ -1,9 +1,11 @@
 import { expect } from "chai";
+import * as sinon from "sinon";
 
 import { functionsEnvFromInstance, parameterizeProject, setSecretParamsToLatest } from "./export";
 import { DeploymentInstanceSpec } from "../deploy/extensions/planner";
-import { ParamType } from "./types";
-import { ExtensionInstance } from "./types";
+import { ExtensionInstance, ParamType } from "./types";
+import { ensureInstanceSpec } from "./extensionsHelper";
+import * as publisherApi from "./publisherApi";
 
 describe("ext:export helpers", () => {
   describe("parameterizeProject", () => {
@@ -330,5 +332,94 @@ describe("functionsEnvFromInstance", () => {
       EXT_SELECTED_EVENTS: "firebase.extensions.storage-resize-images.v1.complete",
       EVENTARC_CHANNEL: "projects/1234/locations/us-west1/channels/firebase",
     });
+  });
+});
+
+describe("ensureInstanceSpec", () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should return instance as is if spec already exists", async () => {
+    const instance: ExtensionInstance = {
+      name: "projects/123/instances/ext1",
+      createTime: "",
+      updateTime: "",
+      state: "ACTIVE",
+      serviceAccountEmail: "",
+      config: {
+        name: "",
+        createTime: "",
+        params: {},
+        systemParams: {},
+        source: {
+          name: "",
+          state: "ACTIVE",
+          packageUri: "",
+          hash: "",
+          spec: {
+            name: "my-ext",
+            version: "0.1.0",
+            resources: [],
+            params: [],
+            systemParams: [],
+          },
+        },
+      },
+    };
+
+    const getExtensionVersionStub = sandbox.stub(publisherApi, "getExtensionVersion");
+    const res = await ensureInstanceSpec(instance);
+    expect(res).to.equal(instance);
+    expect(getExtensionVersionStub).to.not.have.been.called;
+  });
+
+  it("should fetch spec on demand if missing", async () => {
+    const instance: ExtensionInstance = {
+      name: "projects/123/instances/ext1",
+      createTime: "",
+      updateTime: "",
+      state: "ACTIVE",
+      serviceAccountEmail: "",
+      config: {
+        name: "",
+        createTime: "",
+        params: {},
+        systemParams: {},
+        extensionRef: "firebase/firestore-send-email",
+        extensionVersion: "0.1.35",
+      },
+    };
+
+    sandbox.stub(publisherApi, "getExtensionVersion").resolves({
+      name: "publishers/firebase/extensions/firestore-send-email/versions/0.1.35",
+      ref: "firebase/firestore-send-email@0.1.35",
+      spec: {
+        name: "firestore-send-email",
+        version: "0.1.35",
+        resources: [],
+        params: [
+          {
+            param: "LOCATION",
+            label: "Location",
+            type: ParamType.SELECT,
+          },
+        ],
+        systemParams: [],
+      },
+      state: "PUBLISHED",
+      hash: "hash123",
+      sourceDownloadUri: "https://example.com/download",
+    });
+
+    const res = await ensureInstanceSpec(instance);
+    expect(res.config?.source?.spec?.name).to.equal("firestore-send-email");
+    expect(res.config?.source?.spec?.params).to.have.length(1);
   });
 });

--- a/src/extensions/export.spec.ts
+++ b/src/extensions/export.spec.ts
@@ -1,11 +1,8 @@
 import { expect } from "chai";
-import * as sinon from "sinon";
 
 import { functionsEnvFromInstance, parameterizeProject, setSecretParamsToLatest } from "./export";
 import { DeploymentInstanceSpec } from "../deploy/extensions/planner";
 import { ExtensionInstance, ParamType } from "./types";
-import { ensureInstanceSpec } from "./extensionsHelper";
-import * as publisherApi from "./publisherApi";
 
 describe("ext:export helpers", () => {
   describe("parameterizeProject", () => {
@@ -298,6 +295,46 @@ describe("functionsEnvFromInstance", () => {
     });
   });
 
+  it("system params location should map to FUNCTION_DEFAULT_REGION", () => {
+    const instance: ExtensionInstance = {
+      name: "projects/1234/instances/ext1",
+      createTime: "",
+      updateTime: "",
+      state: "ACTIVE",
+      serviceAccountEmail: "",
+      config: {
+        name: "",
+        createTime: "",
+        params: {},
+        systemParams: {},
+        source: {
+          name: "",
+          state: "ACTIVE",
+          packageUri: "",
+          hash: "",
+          spec: {
+            name: "storage-resize-images",
+            version: "0.1.30",
+            resources: [],
+            params: [],
+            systemParams: [
+              {
+                param: "firebaseextensions.v1beta.function/location",
+                label: "Location",
+                default: "us-central1",
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const output = functionsEnvFromInstance(instance);
+    expect(output).to.deep.equal({
+      FUNCTION_DEFAULT_REGION: "us-central1",
+    });
+  });
+
   it("eventarc special cases", () => {
     const instance: ExtensionInstance = {
       name: "",
@@ -332,169 +369,5 @@ describe("functionsEnvFromInstance", () => {
       EXT_SELECTED_EVENTS: "firebase.extensions.storage-resize-images.v1.complete",
       EVENTARC_CHANNEL: "projects/1234/locations/us-west1/channels/firebase",
     });
-  });
-});
-
-describe("ensureInstanceSpec", () => {
-  let sandbox: sinon.SinonSandbox;
-
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
-  it("should return instance as is if spec already exists", async () => {
-    const instance: ExtensionInstance = {
-      name: "projects/123/instances/ext1",
-      createTime: "",
-      updateTime: "",
-      state: "ACTIVE",
-      serviceAccountEmail: "",
-      config: {
-        name: "",
-        createTime: "",
-        params: {},
-        systemParams: {},
-        source: {
-          name: "",
-          state: "ACTIVE",
-          packageUri: "",
-          hash: "",
-          spec: {
-            name: "my-ext",
-            version: "0.1.0",
-            resources: [],
-            params: [],
-            systemParams: [],
-          },
-        },
-      },
-    };
-
-    const getExtensionVersionStub = sandbox.stub(publisherApi, "getExtensionVersion");
-    const res = await ensureInstanceSpec(instance);
-    expect(res).to.equal(instance);
-    expect(getExtensionVersionStub).to.not.have.been.called;
-  });
-
-  it("should fetch spec on demand if missing", async () => {
-    const instance: ExtensionInstance = {
-      name: "projects/123/instances/ext1",
-      createTime: "",
-      updateTime: "",
-      state: "ACTIVE",
-      serviceAccountEmail: "",
-      config: {
-        name: "",
-        createTime: "",
-        params: {},
-        systemParams: {},
-        extensionRef: "firebase/firestore-send-email",
-        extensionVersion: "0.1.35",
-      },
-    };
-
-    sandbox.stub(publisherApi, "getExtensionVersion").resolves({
-      name: "publishers/firebase/extensions/firestore-send-email/versions/0.1.35",
-      ref: "firebase/firestore-send-email@0.1.35",
-      spec: {
-        name: "firestore-send-email",
-        version: "0.1.35",
-        resources: [],
-        params: [
-          {
-            param: "LOCATION",
-            label: "Location",
-            type: ParamType.SELECT,
-          },
-        ],
-        systemParams: [],
-      },
-      state: "PUBLISHED",
-      hash: "hash123",
-      sourceDownloadUri: "https://example.com/download",
-    });
-
-    const res = await ensureInstanceSpec(instance);
-    expect(res.config?.source?.spec?.name).to.equal("firestore-send-email");
-    expect(res.config?.source?.spec?.params).to.have.length(1);
-    expect(res.config?.source?.name).to.equal(
-      "publishers/firebase/extensions/firestore-send-email/versions/0.1.35",
-    );
-    expect(res.config?.source?.packageUri).to.equal("https://example.com/download");
-    expect(res.config?.source?.hash).to.equal("hash123");
-    expect(res.config?.source?.state).to.equal("ACTIVE");
-  });
-
-  it("should fetch spec on demand if extensionRef is on instance directly", async () => {
-    const instance: ExtensionInstance = {
-      name: "projects/123/instances/ext1",
-      createTime: "",
-      updateTime: "",
-      state: "ACTIVE",
-      serviceAccountEmail: "",
-      extensionRef: "firebase/firestore-send-email",
-      extensionVersion: "0.1.35",
-      config: {
-        name: "",
-        createTime: "",
-        params: {},
-        systemParams: {},
-      },
-    };
-
-    sandbox.stub(publisherApi, "getExtensionVersion").resolves({
-      name: "publishers/firebase/extensions/firestore-send-email/versions/0.1.35",
-      ref: "firebase/firestore-send-email@0.1.35",
-      spec: {
-        name: "firestore-send-email",
-        version: "0.1.35",
-        resources: [],
-        params: [
-          {
-            param: "LOCATION",
-            label: "Location",
-            type: ParamType.SELECT,
-          },
-        ],
-        systemParams: [],
-      },
-      state: "PUBLISHED",
-      hash: "hash123",
-      sourceDownloadUri: "https://example.com/download",
-    });
-
-    const res = await ensureInstanceSpec(instance);
-    expect(res.config?.source?.spec?.name).to.equal("firestore-send-email");
-    expect(res.config?.source?.spec?.params).to.have.length(1);
-    expect(res.config?.source?.name).to.equal(
-      "publishers/firebase/extensions/firestore-send-email/versions/0.1.35",
-    );
-  });
-
-  it("should let getExtensionVersion errors bubble up", async () => {
-    const instance: ExtensionInstance = {
-      name: "projects/123/instances/ext1",
-      createTime: "",
-      updateTime: "",
-      state: "ACTIVE",
-      serviceAccountEmail: "",
-      extensionRef: "firebase/firestore-send-email",
-      extensionVersion: "0.1.35",
-      config: {
-        name: "",
-        createTime: "",
-        params: {},
-        systemParams: {},
-      },
-    };
-
-    const networkErr = new Error("Network failure");
-    sandbox.stub(publisherApi, "getExtensionVersion").rejects(networkErr);
-
-    await expect(ensureInstanceSpec(instance)).to.be.rejectedWith(networkErr);
   });
 });

--- a/src/extensions/export.spec.ts
+++ b/src/extensions/export.spec.ts
@@ -422,4 +422,47 @@ describe("ensureInstanceSpec", () => {
     expect(res.config?.source?.spec?.name).to.equal("firestore-send-email");
     expect(res.config?.source?.spec?.params).to.have.length(1);
   });
+
+  it("should fetch spec on demand if extensionRef is on instance directly", async () => {
+    const instance: ExtensionInstance = {
+      name: "projects/123/instances/ext1",
+      createTime: "",
+      updateTime: "",
+      state: "ACTIVE",
+      serviceAccountEmail: "",
+      extensionRef: "firebase/firestore-send-email",
+      extensionVersion: "0.1.35",
+      config: {
+        name: "",
+        createTime: "",
+        params: {},
+        systemParams: {},
+      },
+    };
+
+    sandbox.stub(publisherApi, "getExtensionVersion").resolves({
+      name: "publishers/firebase/extensions/firestore-send-email/versions/0.1.35",
+      ref: "firebase/firestore-send-email@0.1.35",
+      spec: {
+        name: "firestore-send-email",
+        version: "0.1.35",
+        resources: [],
+        params: [
+          {
+            param: "LOCATION",
+            label: "Location",
+            type: ParamType.SELECT,
+          },
+        ],
+        systemParams: [],
+      },
+      state: "PUBLISHED",
+      hash: "hash123",
+      sourceDownloadUri: "https://example.com/download",
+    });
+
+    const res = await ensureInstanceSpec(instance);
+    expect(res.config?.source?.spec?.name).to.equal("firestore-send-email");
+    expect(res.config?.source?.spec?.params).to.have.length(1);
+  });
 });

--- a/src/extensions/export.ts
+++ b/src/extensions/export.ts
@@ -129,7 +129,7 @@ export function functionsEnvFromInstance(instance: ExtensionInstance): Record<st
       .replace(/^firebaseextensions\.v1beta\.(v2)?function\//, "EXT_MIGRATED_SYSTEM_")
       .toUpperCase();
     if (renamed === "EXT_MIGRATED_SYSTEM_LOCATION") {
-      renamed = "DEFAULT_FUNCTION_REGION";
+      renamed = "FUNCTION_DEFAULT_REGION";
     }
     envs[renamed] = sysParamValue;
   }
@@ -142,7 +142,7 @@ export function functionsEnvFromInstance(instance: ExtensionInstance): Record<st
         .replace(/^firebaseextensions\.v1beta\.(v2)?function\//, "EXT_MIGRATED_SYSTEM_")
         .toUpperCase();
       if (renamed === "EXT_MIGRATED_SYSTEM_LOCATION") {
-        renamed = "DEFAULT_FUNCTION_REGION";
+        renamed = "FUNCTION_DEFAULT_REGION";
       }
       envs[renamed] = specSystemParam.default ?? "";
     }

--- a/src/extensions/export.ts
+++ b/src/extensions/export.ts
@@ -105,8 +105,8 @@ function displaySpecs(specs: DeploymentInstanceSpec[]): void {
 export function functionsEnvFromInstance(instance: ExtensionInstance): Record<string, string> {
   const liveParams = instance.config?.params || {};
   const liveSystemParams = instance.config?.systemParams || {};
-  const specParams = instance.config?.source?.spec?.params || {};
-  const specSystemParams = instance.config?.source?.spec?.systemParams || {};
+  const specParams = instance.config?.source?.spec?.params || [];
+  const specSystemParams = instance.config?.source?.spec?.systemParams || [];
 
   const envs: Record<string, string> = {};
 
@@ -132,14 +132,17 @@ export function functionsEnvFromInstance(instance: ExtensionInstance): Record<st
     }
     envs[renamed] = sysParamValue;
   }
-  for (const specSystemParam of Object.values(specSystemParams)) {
+  for (const specSystemParam of specSystemParams) {
     if (specSystemParam.param in liveSystemParams) {
       continue;
     }
     if ("default" in specSystemParam) {
-      const renamed = specSystemParam.param
+      let renamed = specSystemParam.param
         .replace(/^firebaseextensions\.v1beta\.(v2)?function\//, "EXT_MIGRATED_SYSTEM_")
         .toUpperCase();
+      if (renamed === "EXT_MIGRATED_SYSTEM_LOCATION") {
+        renamed = "DEFAULT_FUNCTION_REGION";
+      }
       envs[renamed] = specSystemParam.default ?? "";
     }
   }

--- a/src/extensions/extensionsHelper.spec.ts
+++ b/src/extensions/extensionsHelper.spec.ts
@@ -12,6 +12,7 @@ import { storage } from "../gcp";
 import * as archiveDirectory from "../archiveDirectory";
 import * as prompt from "../prompt";
 import {
+  ExtensionInstance,
   ExtensionSource,
   ExtensionSpec,
   Param,
@@ -1000,6 +1001,208 @@ describe("extensionsHelper", () => {
           state: "PUBLISHED",
         }),
       ).to.eql("Prerelease");
+    });
+  });
+
+  describe("ensureInstanceSpec", () => {
+    let sandbox: sinon.SinonSandbox;
+
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("should return instance as is if spec already exists", async () => {
+      const instance: ExtensionInstance = {
+        name: "projects/123/instances/ext1",
+        createTime: "",
+        updateTime: "",
+        state: "ACTIVE",
+        serviceAccountEmail: "",
+        config: {
+          name: "",
+          createTime: "",
+          params: {},
+          systemParams: {},
+          source: {
+            name: "",
+            state: "ACTIVE",
+            packageUri: "",
+            hash: "",
+            spec: {
+              name: "my-ext",
+              version: "0.1.0",
+              resources: [],
+              params: [],
+              systemParams: [],
+            },
+          },
+        },
+      };
+
+      const getExtensionVersionStub = sandbox.stub(publisherApi, "getExtensionVersion");
+      const res = await extensionsHelper.ensureInstanceSpec(instance);
+      expect(res).to.equal(instance);
+      expect(getExtensionVersionStub).to.not.have.been.called;
+    });
+
+    it("should fetch spec on demand if missing", async () => {
+      const instance: ExtensionInstance = {
+        name: "projects/123/instances/ext1",
+        createTime: "",
+        updateTime: "",
+        state: "ACTIVE",
+        serviceAccountEmail: "",
+        config: {
+          name: "",
+          createTime: "",
+          params: {},
+          systemParams: {},
+          extensionRef: "firebase/firestore-send-email",
+          extensionVersion: "0.1.35",
+        },
+      };
+
+      sandbox.stub(publisherApi, "getExtensionVersion").resolves({
+        name: "publishers/firebase/extensions/firestore-send-email/versions/0.1.35",
+        ref: "firebase/firestore-send-email@0.1.35",
+        spec: {
+          name: "firestore-send-email",
+          version: "0.1.35",
+          resources: [],
+          params: [
+            {
+              param: "LOCATION",
+              label: "Location",
+              type: ParamType.SELECT,
+            },
+          ],
+          systemParams: [],
+        },
+        state: "PUBLISHED",
+        hash: "hash123",
+        sourceDownloadUri: "https://example.com/download",
+      });
+
+      const res = await extensionsHelper.ensureInstanceSpec(instance);
+      expect(res.config?.source?.spec?.name).to.equal("firestore-send-email");
+      expect(res.config?.source?.spec?.params).to.have.length(1);
+      expect(res.config?.source?.name).to.equal(
+        "publishers/firebase/extensions/firestore-send-email/versions/0.1.35",
+      );
+      expect(res.config?.source?.packageUri).to.equal("https://example.com/download");
+      expect(res.config?.source?.hash).to.equal("hash123");
+      expect(res.config?.source?.state).to.equal("ACTIVE");
+    });
+
+    it("should fetch spec on demand if extensionRef is on instance directly", async () => {
+      const instance: ExtensionInstance = {
+        name: "projects/123/instances/ext1",
+        createTime: "",
+        updateTime: "",
+        state: "ACTIVE",
+        serviceAccountEmail: "",
+        extensionRef: "firebase/firestore-send-email",
+        extensionVersion: "0.1.35",
+        config: {
+          name: "",
+          createTime: "",
+          params: {},
+          systemParams: {},
+        },
+      };
+
+      sandbox.stub(publisherApi, "getExtensionVersion").resolves({
+        name: "publishers/firebase/extensions/firestore-send-email/versions/0.1.35",
+        ref: "firebase/firestore-send-email@0.1.35",
+        spec: {
+          name: "firestore-send-email",
+          version: "0.1.35",
+          resources: [],
+          params: [
+            {
+              param: "LOCATION",
+              label: "Location",
+              type: ParamType.SELECT,
+            },
+          ],
+          systemParams: [],
+        },
+        state: "PUBLISHED",
+        hash: "hash123",
+        sourceDownloadUri: "https://example.com/download",
+      });
+
+      const res = await extensionsHelper.ensureInstanceSpec(instance);
+      expect(res.config?.source?.spec?.name).to.equal("firestore-send-email");
+      expect(res.config?.source?.spec?.params).to.have.length(1);
+      expect(res.config?.source?.name).to.equal(
+        "publishers/firebase/extensions/firestore-send-email/versions/0.1.35",
+      );
+    });
+
+    it("should preserve version from extensionRef when extensionVersion is unset", async () => {
+      const instance: ExtensionInstance = {
+        name: "projects/123/instances/ext1",
+        createTime: "",
+        updateTime: "",
+        state: "ACTIVE",
+        serviceAccountEmail: "",
+        extensionRef: "firebase/firestore-send-email@0.1.35",
+        config: {
+          name: "",
+          createTime: "",
+          params: {},
+          systemParams: {},
+        },
+      };
+
+      const getExtensionVersionStub = sandbox.stub(publisherApi, "getExtensionVersion").resolves({
+        name: "publishers/firebase/extensions/firestore-send-email/versions/0.1.35",
+        ref: "firebase/firestore-send-email@0.1.35",
+        spec: {
+          name: "firestore-send-email",
+          version: "0.1.35",
+          resources: [],
+          params: [],
+          systemParams: [],
+        },
+        state: "PUBLISHED",
+        hash: "hash123",
+        sourceDownloadUri: "https://example.com/download",
+      });
+
+      const res = await extensionsHelper.ensureInstanceSpec(instance);
+      expect(getExtensionVersionStub).to.have.been.calledWith(
+        "firebase/firestore-send-email@0.1.35",
+      );
+      expect(res.config?.source?.spec?.name).to.equal("firestore-send-email");
+    });
+
+    it("should let getExtensionVersion errors bubble up", async () => {
+      const instance: ExtensionInstance = {
+        name: "projects/123/instances/ext1",
+        createTime: "",
+        updateTime: "",
+        state: "ACTIVE",
+        serviceAccountEmail: "",
+        extensionRef: "firebase/firestore-send-email",
+        extensionVersion: "0.1.35",
+        config: {
+          name: "",
+          createTime: "",
+          params: {},
+          systemParams: {},
+        },
+      };
+
+      const networkErr = new Error("Network failure");
+      sandbox.stub(publisherApi, "getExtensionVersion").rejects(networkErr);
+
+      await expect(extensionsHelper.ensureInstanceSpec(instance)).to.be.rejectedWith(networkErr);
     });
   });
 });

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -1271,8 +1271,8 @@ export async function ensureInstanceSpec(instance: ExtensionInstance): Promise<E
     return instance;
   }
 
-  const extensionRef = instance.config?.extensionRef;
-  const extensionVersion = instance.config?.extensionVersion;
+  const extensionRef = instance.config?.extensionRef ?? instance.extensionRef;
+  const extensionVersion = instance.config?.extensionVersion ?? instance.extensionVersion;
 
   if (extensionRef) {
     try {

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -15,7 +15,7 @@ import { extensionsOrigin, extensionsPublisherOrigin, storageOrigin } from "../a
 import { archiveDirectory } from "../archiveDirectory";
 import { getFirebaseConfig } from "../functionsConfig";
 import { getProjectAdminSdkConfigOrCached } from "../emulator/adminSdkConfig";
-import { FirebaseError } from "../error";
+import { getErrMsg, FirebaseError } from "../error";
 import { diagnose } from "./diagnose";
 import { checkResponse } from "./askUserForParam";
 import { ensure, check } from "../ensureApiEnabled";
@@ -30,7 +30,14 @@ import {
   listExtensionVersions,
 } from "./publisherApi";
 import { Choice, confirm, input, select } from "../prompt";
-import { Extension, ExtensionSource, ExtensionSpec, ExtensionVersion, Param } from "./types";
+import {
+  Extension,
+  ExtensionInstance,
+  ExtensionSource,
+  ExtensionSpec,
+  ExtensionVersion,
+  Param,
+} from "./types";
 import * as refs from "./refs";
 import { EXTENSIONS_SPEC_FILE, readFile, getLocalExtensionSpec } from "./localHelper";
 import { logger } from "../logger";
@@ -1254,4 +1261,47 @@ export async function diagnoseAndFixProject(options: any): Promise<void> {
   if (!ok) {
     throw new FirebaseError("Unable to proceed until all issues are resolved.");
   }
+}
+
+/**
+ * Ensures that the extension instance has its spec loaded, fetching it on demand if missing.
+ */
+export async function ensureInstanceSpec(instance: ExtensionInstance): Promise<ExtensionInstance> {
+  if (instance.config?.source?.spec) {
+    return instance;
+  }
+
+  const extensionRef = instance.config?.extensionRef;
+  const extensionVersion = instance.config?.extensionVersion;
+
+  if (extensionRef) {
+    try {
+      const ref = refs.parse(extensionRef);
+      const version = extensionVersion ? extensionVersion : "latest";
+      const extVersion = await getExtensionVersion(
+        `${ref.publisherId}/${ref.extensionId}@${version}`,
+      );
+      if (extVersion?.spec) {
+        return {
+          ...instance,
+          config: {
+            ...instance.config,
+            source: {
+              ...(instance.config?.source ?? {
+                state: "ACTIVE",
+                name: "",
+                packageUri: "",
+                hash: "",
+              }),
+              spec: extVersion.spec,
+            },
+          },
+        };
+      }
+    } catch (err: unknown) {
+      logger.debug(`Failed to fetch extension version for ${extensionRef}: ${getErrMsg(err)}`);
+    }
+  }
+
+  return instance;
 }

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -15,7 +15,7 @@ import { extensionsOrigin, extensionsPublisherOrigin, storageOrigin } from "../a
 import { archiveDirectory } from "../archiveDirectory";
 import { getFirebaseConfig } from "../functionsConfig";
 import { getProjectAdminSdkConfigOrCached } from "../emulator/adminSdkConfig";
-import { getErrMsg, FirebaseError } from "../error";
+import { FirebaseError } from "../error";
 import { diagnose } from "./diagnose";
 import { checkResponse } from "./askUserForParam";
 import { ensure, check } from "../ensureApiEnabled";
@@ -1272,36 +1272,31 @@ export async function ensureInstanceSpec(instance: ExtensionInstance): Promise<E
   }
 
   const extensionRef = instance.config?.extensionRef ?? instance.extensionRef;
-  const extensionVersion = instance.config?.extensionVersion ?? instance.extensionVersion;
-
-  if (extensionRef) {
-    try {
-      const ref = refs.parse(extensionRef);
-      const version = extensionVersion ? extensionVersion : "latest";
-      const extVersion = await getExtensionVersion(
-        `${ref.publisherId}/${ref.extensionId}@${version}`,
-      );
-      if (extVersion?.spec) {
-        return {
-          ...instance,
-          config: {
-            ...instance.config,
-            source: {
-              ...(instance.config?.source ?? {
-                state: "ACTIVE",
-                name: "",
-                packageUri: "",
-                hash: "",
-              }),
-              spec: extVersion.spec,
-            },
-          },
-        };
-      }
-    } catch (err: unknown) {
-      logger.debug(`Failed to fetch extension version for ${extensionRef}: ${getErrMsg(err)}`);
-    }
+  if (!extensionRef) {
+    return instance;
   }
 
-  return instance;
+  const extensionVersion =
+    instance.config?.extensionVersion ?? instance.extensionVersion ?? "latest";
+  const ref = refs.parse(extensionRef);
+  const extVersion = await getExtensionVersion(
+    `${ref.publisherId}/${ref.extensionId}@${extensionVersion}`,
+  );
+
+  return {
+    ...instance,
+    config: {
+      ...instance.config,
+      source: {
+        ...instance.config?.source,
+        name: instance.config?.source?.name ?? extVersion.name,
+        state:
+          instance.config?.source?.state ??
+          (extVersion.state === "PUBLISHED" ? "ACTIVE" : "STATE_UNSPECIFIED"),
+        packageUri: instance.config?.source?.packageUri ?? extVersion.sourceDownloadUri,
+        hash: instance.config?.source?.hash ?? extVersion.hash,
+        spec: extVersion.spec,
+      },
+    },
+  };
 }

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -1276,9 +1276,9 @@ export async function ensureInstanceSpec(instance: ExtensionInstance): Promise<E
     return instance;
   }
 
-  const extensionVersion =
-    instance.config?.extensionVersion ?? instance.extensionVersion ?? "latest";
   const ref = refs.parse(extensionRef);
+  const extensionVersion =
+    instance.config?.extensionVersion ?? instance.extensionVersion ?? ref.version ?? "latest";
   const extVersion = await getExtensionVersion(
     `${ref.publisherId}/${ref.extensionId}@${extensionVersion}`,
   );

--- a/src/extensions/secretsUtils.ts
+++ b/src/extensions/secretsUtils.ts
@@ -33,7 +33,7 @@ export async function grantFirexServiceAgentSecretAdminRole(
 }
 
 export async function getManagedSecrets(instance: ExtensionInstance): Promise<string[]> {
-  if (!instance.config.source?.spec) {
+  if (!instance.config?.source?.spec) {
     return [];
   }
   return (

--- a/src/extensions/secretsUtils.ts
+++ b/src/extensions/secretsUtils.ts
@@ -33,6 +33,9 @@ export async function grantFirexServiceAgentSecretAdminRole(
 }
 
 export async function getManagedSecrets(instance: ExtensionInstance): Promise<string[]> {
+  if (!instance.config.source?.spec) {
+    return [];
+  }
   return (
     await Promise.all(
       getActiveSecrets(instance.config.source.spec, instance.config.params).map(

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -99,7 +99,7 @@ export const isExtensionInstance = (value: unknown): value is ExtensionInstance 
 export interface ExtensionConfig {
   name: string;
   createTime: string;
-  source: ExtensionSource;
+  source?: ExtensionSource;
   params: Record<string, string>;
   systemParams: Record<string, string>;
   populatedPostinstallContent?: string;


### PR DESCRIPTION
### Description
- Updates `ExtensionConfig` interface to make `source?: ExtensionSource` optional, reflecting runtime API behavior for published extension instances.
- Adds `ensureInstanceSpec` in `extensionsHelper.ts` to fetch an extension version's specification on demand when `instance.config.source?.spec` is absent.
- Adds defensive guards when accessing `instance.config.source?.spec` in `secretsUtils.ts` and `export.ts`.

### Scenarios Tested
- Added unit tests in `src/extensions/export.spec.ts` for `ensureInstanceSpec`:
  - Returns instance unchanged when spec is already present.
  - Fetches spec on demand from the Extension publisher API when missing.
- Verified TypeScript compilation and ESLint checks.

### Sample Commands
- `npm test`
