### PR TITLE
feat(functions): support seedEnv in kit installation and instance configuration

### DIFF
--- a/src/functions/kits/install.spec.ts
+++ b/src/functions/kits/install.spec.ts
@@ -1986,9 +1986,9 @@ describe("functions/kits/install", () => {
         existingKit,
         {
           existingFunctions: [existingKit],
-          existingKitIds: new Set(["firestore-bigquery-export"]),
-          existingCodebases: new Set(),
-          existingInstanceIds: new Set(["inst1"]),
+          existingKitIds: ["firestore-bigquery-export"],
+          existingCodebases: [],
+          existingInstanceIds: ["inst1"],
         },
       );
 

--- a/src/functions/kits/install.spec.ts
+++ b/src/functions/kits/install.spec.ts
@@ -2345,28 +2345,6 @@ describe("functions/kits/install", () => {
       });
     });
 
-    it("should suppress first deploy report when skipReport is true", async () => {
-      const mockConfig = {
-        projectDir: "/mock/project",
-        src: { functions: [] },
-        path: (p: string) => path.join("/mock/project", p),
-        writeProjectFile: sinon.stub(),
-        askWriteProjectFile: sinon.stub().resolves(),
-      } as unknown as Config;
-
-      const getRuntimeDelegateStub = sinon.stub(runtimes, "getRuntimeDelegate");
-
-      await installKitOrInstance({
-        config: mockConfig,
-        package: "@firebase-function-kits/firestore-bigquery-export@1.0.0",
-        nonInteractive: true,
-        configure: false,
-        skipReport: true,
-      });
-
-      expect(getRuntimeDelegateStub).to.not.have.been.called;
-    });
-
     it("should handle existing kit when package is already in firebase.json", async () => {
       const existingKit: ValidatedKitSingle = {
         kit: "firestore-bigquery-export",

--- a/src/functions/kits/install.spec.ts
+++ b/src/functions/kits/install.spec.ts
@@ -1967,6 +1967,62 @@ describe("functions/kits/install", () => {
       });
     });
 
+    it("should seed env for existing instance when seedEnv is provided", async () => {
+      const existingKit: ValidatedKitSingle = {
+        kit: "firestore-bigquery-export",
+        sourcePackage: { name: "@firebase-function-kits/firestore-bigquery-export" },
+        source: "function-kits/firestore-bigquery-export/source",
+        instances: {
+          inst1: "function-kits/firestore-bigquery-export/config-inst1",
+        },
+      };
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: { functions: [existingKit] },
+        path: (p: string) => path.join("/mock/project", p),
+      } as unknown as Config;
+
+      sinon.stub(prompt, "select").resolves("addEnv");
+
+      const res = await addKitInstanceOrConfigureProject(
+        {
+          config: mockConfig,
+          project: "my-project",
+          seedEnv: {
+            projectId: "my-project",
+            envs: {
+              FOO: "bar",
+            },
+          },
+        },
+        existingKit,
+        {
+          existingFunctions: [existingKit],
+          existingKitIds: new Set(["firestore-bigquery-export"]),
+          existingCodebases: new Set(),
+          existingInstanceIds: new Set(["inst1"]),
+        },
+      );
+
+      expect(seedKitInstanceEnvStub).to.have.been.calledOnceWith({
+        configDir: path.join(
+          "/mock/project",
+          "function-kits/firestore-bigquery-export/config-inst1",
+        ),
+        functionsSource: path.join(
+          "/mock/project",
+          "function-kits/firestore-bigquery-export/source",
+        ),
+        projectDir: "/mock/project",
+        projectId: "my-project",
+        projectAlias: undefined,
+        envs: {
+          FOO: "bar",
+        },
+      });
+      expect(res.action).to.equal("configuredEnv");
+    });
+
     it("should prompt and write params when configuring env for existing instance with params", async () => {
       const existingKit: ValidatedKitSingle = {
         kit: "firestore-bigquery-export",
@@ -2299,6 +2355,28 @@ describe("functions/kits/install", () => {
           PARAM_ONE: "value1",
         },
       });
+    });
+
+    it("should suppress first deploy report when skipReport is true", async () => {
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: { functions: [] },
+        path: (p: string) => path.join("/mock/project", p),
+        writeProjectFile: sinon.stub(),
+        askWriteProjectFile: sinon.stub().resolves(),
+      } as unknown as Config;
+
+      const getRuntimeDelegateStub = sinon.stub(runtimes, "getRuntimeDelegate");
+
+      await installKitOrInstance({
+        config: mockConfig,
+        package: "@firebase-function-kits/firestore-bigquery-export@1.0.0",
+        nonInteractive: true,
+        configure: false,
+        skipReport: true,
+      });
+
+      expect(getRuntimeDelegateStub).to.not.have.been.called;
     });
 
     it("should handle existing kit when package is already in firebase.json", async () => {

--- a/src/functions/kits/install.spec.ts
+++ b/src/functions/kits/install.spec.ts
@@ -128,20 +128,20 @@ describe("functions/kits/install", () => {
 
   describe("generateUniqueId", () => {
     it("should return base ID when it is not in existing IDs", () => {
-      const existing = new Set(["other-kit"]);
+      const existing = ["other-kit"];
       expect(generateUniqueId("my-kit", existing)).to.equal("my-kit");
     });
 
     it("should append random 4-character hex suffix when base ID collides", () => {
-      const existing = new Set(["my-kit"]);
+      const existing = ["my-kit"];
       const res = generateUniqueId("my-kit", existing);
       expect(res).to.match(/^my-kit-[a-f0-9]{4}$/);
-      expect(existing.has(res)).to.be.false;
+      expect(existing.includes(res)).to.be.false;
     });
 
     it("should truncate long base IDs to ensure total length <= 40", () => {
       const longBase = "a".repeat(40);
-      const existing = new Set([longBase]);
+      const existing = [longBase];
       const res = generateUniqueId(longBase, existing);
       expect(res.length).to.be.at.most(40);
       expect(res).to.match(/^a{35}-[a-f0-9]{4}$/);
@@ -314,18 +314,18 @@ describe("functions/kits/install", () => {
   });
 
   describe("extractExistingFunctionsInfo", () => {
-    it("should return empty sets when configFunctions is undefined or empty", () => {
+    it("should return empty arrays when configFunctions is undefined or empty", () => {
       const resUndefined = extractExistingFunctionsInfo(undefined);
       expect(resUndefined.existingFunctions).to.deep.equal([]);
-      expect(resUndefined.existingKitIds.size).to.equal(0);
-      expect(resUndefined.existingCodebases.size).to.equal(0);
-      expect(resUndefined.existingInstanceIds.size).to.equal(0);
+      expect(resUndefined.existingKitIds).to.deep.equal([]);
+      expect(resUndefined.existingCodebases).to.deep.equal([]);
+      expect(resUndefined.existingInstanceIds).to.deep.equal([]);
 
       const resEmpty = extractExistingFunctionsInfo([]);
       expect(resEmpty.existingFunctions).to.deep.equal([]);
-      expect(resEmpty.existingKitIds.size).to.equal(0);
-      expect(resEmpty.existingCodebases.size).to.equal(0);
-      expect(resEmpty.existingInstanceIds.size).to.equal(0);
+      expect(resEmpty.existingKitIds).to.deep.equal([]);
+      expect(resEmpty.existingCodebases).to.deep.equal([]);
+      expect(resEmpty.existingInstanceIds).to.deep.equal([]);
     });
 
     it("should extract kit IDs, instance IDs, and codebases correctly", () => {
@@ -345,10 +345,10 @@ describe("functions/kits/install", () => {
       ];
 
       const res = extractExistingFunctionsInfo(functionsConfig);
-      expect(res.existingCodebases.has("my-codebase")).to.be.true;
-      expect(res.existingKitIds.has("my-kit")).to.be.true;
-      expect(res.existingInstanceIds.has("inst-1")).to.be.true;
-      expect(res.existingInstanceIds.has("inst-2")).to.be.true;
+      expect(res.existingCodebases).to.include("my-codebase");
+      expect(res.existingKitIds).to.include("my-kit");
+      expect(res.existingInstanceIds).to.include("inst-1");
+      expect(res.existingInstanceIds).to.include("inst-2");
     });
   });
 
@@ -1060,8 +1060,8 @@ describe("functions/kits/install", () => {
     it("should return custom instance ID directly if provided and valid", async () => {
       const res = await promptKitInstanceId(
         "my-kit",
-        new Set(["other-inst"]),
-        new Set(["codebase1"]),
+        ["other-inst"],
+        ["codebase1"],
         false,
         "valid-custom-inst",
       );
@@ -1070,50 +1070,38 @@ describe("functions/kits/install", () => {
 
     it("should throw if custom instance ID collides with existing instances", async () => {
       await expect(
-        promptKitInstanceId(
-          "my-kit",
-          new Set(["existing-inst"]),
-          new Set(),
-          false,
-          "existing-inst",
-        ),
+        promptKitInstanceId("my-kit", ["existing-inst"], [], false, "existing-inst"),
       ).to.be.rejectedWith(FirebaseError, /must be unique across all kits/);
     });
 
     it("should throw if custom instance ID collides with codebase name", async () => {
       await expect(
-        promptKitInstanceId(
-          "my-kit",
-          new Set(),
-          new Set(["existing-codebase"]),
-          false,
-          "existing-codebase",
-        ),
+        promptKitInstanceId("my-kit", [], ["existing-codebase"], false, "existing-codebase"),
       ).to.be.rejectedWith(FirebaseError, /must be mutually exclusive/);
     });
 
     it("should prompt user when custom instance ID is not provided", async () => {
       sinon.stub(prompt, "input").resolves("prompted-inst");
-      const res = await promptKitInstanceId("my-kit", new Set(), new Set());
+      const res = await promptKitInstanceId("my-kit", [], []);
       expect(res).to.equal("prompted-inst");
     });
   });
 
   describe("promptKitId", () => {
     it("should return custom kit ID directly if provided and valid", async () => {
-      const res = await promptKitId("my-pkg", new Set(["other-kit"]), false, "custom-kit-id");
+      const res = await promptKitId("my-pkg", ["other-kit"], false, "custom-kit-id");
       expect(res).to.equal("custom-kit-id");
     });
 
     it("should throw if custom kit ID collides with existing kit IDs", async () => {
       await expect(
-        promptKitId("my-pkg", new Set(["existing-kit"]), false, "existing-kit"),
+        promptKitId("my-pkg", ["existing-kit"], false, "existing-kit"),
       ).to.be.rejectedWith(FirebaseError, /functions.kit must be unique/);
     });
 
     it("should prompt user when custom kit ID is not provided", async () => {
       sinon.stub(prompt, "input").resolves("prompted-kit");
-      const res = await promptKitId("my-pkg", new Set());
+      const res = await promptKitId("my-pkg", []);
       expect(res).to.equal("prompted-kit");
     });
   });
@@ -1850,9 +1838,9 @@ describe("functions/kits/install", () => {
         existingKit,
         {
           existingFunctions: [existingKit],
-          existingKitIds: new Set(["firestore-bigquery-export"]),
-          existingCodebases: new Set(),
-          existingInstanceIds: new Set(["inst1"]),
+          existingKitIds: ["firestore-bigquery-export"],
+          existingCodebases: [],
+          existingInstanceIds: ["inst1"],
         },
       );
 
@@ -1916,9 +1904,9 @@ describe("functions/kits/install", () => {
         existingKit,
         {
           existingFunctions: [existingKit],
-          existingKitIds: new Set(["firestore-bigquery-export"]),
-          existingCodebases: new Set(),
-          existingInstanceIds: new Set(["inst1"]),
+          existingKitIds: ["firestore-bigquery-export"],
+          existingCodebases: [],
+          existingInstanceIds: ["inst1"],
         },
       );
 
@@ -1952,9 +1940,9 @@ describe("functions/kits/install", () => {
         existingKit,
         {
           existingFunctions: [existingKit],
-          existingKitIds: new Set(["firestore-bigquery-export"]),
-          existingCodebases: new Set(),
-          existingInstanceIds: new Set(["inst1"]),
+          existingKitIds: ["firestore-bigquery-export"],
+          existingCodebases: [],
+          existingInstanceIds: ["inst1"],
         },
       );
 
@@ -2011,9 +1999,9 @@ describe("functions/kits/install", () => {
         existingKit,
         {
           existingFunctions: [existingKit],
-          existingKitIds: new Set(["firestore-bigquery-export"]),
-          existingCodebases: new Set(),
-          existingInstanceIds: new Set(["inst1"]),
+          existingKitIds: ["firestore-bigquery-export"],
+          existingCodebases: [],
+          existingInstanceIds: ["inst1"],
         },
       );
 
@@ -2057,9 +2045,9 @@ describe("functions/kits/install", () => {
         existingKit,
         {
           existingFunctions: [existingKit],
-          existingKitIds: new Set(["firestore-bigquery-export"]),
-          existingCodebases: new Set(),
-          existingInstanceIds: new Set(["inst1"]),
+          existingKitIds: ["firestore-bigquery-export"],
+          existingCodebases: [],
+          existingInstanceIds: ["inst1"],
         },
       );
 

--- a/src/functions/kits/install.ts
+++ b/src/functions/kits/install.ts
@@ -109,7 +109,6 @@ export interface InstallKitOrInstanceOptions {
   project?: string;
   projectId?: string;
   rc?: RC;
-  skipReport?: boolean;
 }
 
 export interface InstallKitOrInstanceResult {
@@ -137,7 +136,6 @@ export interface ExistingKitInstallOptions {
   rc?: RC;
   instanceId?: string;
   seedEnv?: KitInstanceEnvSeed;
-  skipReport?: boolean;
 }
 
 export interface PromptAndWriteKitParamsOptions {
@@ -1129,16 +1127,14 @@ export async function addKitInstanceOrConfigureProject(
     );
   }
 
-  if (!options.skipReport) {
-    await printKitFirstDeployReport({
-      config: options.config,
-      project: options.project,
-      projectId: options.projectId,
-      instanceId,
-      absSourcePath,
-      preDiscoveredBuild: discoveredBuild,
-    });
-  }
+  await printKitFirstDeployReport({
+    config: options.config,
+    project: options.project,
+    projectId: options.projectId,
+    instanceId,
+    absSourcePath,
+    preDiscoveredBuild: discoveredBuild,
+  });
 
   return {
     action: resultAction,
@@ -1357,16 +1353,14 @@ export async function installKitOrInstance(
   });
 
   logLabeledSuccess("functions", `Function kit ${clc.bold(kitId)} successfully installed.`);
-  if (!options.skipReport) {
-    await printKitFirstDeployReport({
-      config: options.config,
-      project: options.project,
-      projectId: options.projectId,
-      instanceId,
-      absSourcePath,
-      preDiscoveredBuild: discoveredBuild,
-    });
-  }
+  await printKitFirstDeployReport({
+    config: options.config,
+    project: options.project,
+    projectId: options.projectId,
+    instanceId,
+    absSourcePath,
+    preDiscoveredBuild: discoveredBuild,
+  });
 
   return {
     action: "installedKit",

--- a/src/functions/kits/install.ts
+++ b/src/functions/kits/install.ts
@@ -48,9 +48,9 @@ export const FUNCTION_KITS_DIR = "function-kits";
 
 export interface ExistingFunctionsInfo {
   existingFunctions: ValidatedSingle[];
-  existingKitIds: Set<string>;
-  existingCodebases: Set<string>;
-  existingInstanceIds: Set<string>;
+  existingKitIds: string[];
+  existingCodebases: string[];
+  existingInstanceIds: string[];
 }
 
 export interface ScaffoldedKitPaths {
@@ -163,8 +163,8 @@ export interface PrintKitFirstDeployReportOptions {
  * Generates a unique identifier by appending a random 4-character hex suffix if a collision exists.
  * Ensures the candidate is truncated so the total length does not exceed 40 characters.
  */
-export function generateUniqueId(baseId: string, existingIds: Set<string>): string {
-  if (!existingIds.has(baseId)) {
+export function generateUniqueId(baseId: string, existingIds: string[]): string {
+  if (!existingIds.includes(baseId)) {
     return baseId;
   }
   const prefix = baseId.slice(0, 35);
@@ -172,7 +172,7 @@ export function generateUniqueId(baseId: string, existingIds: Set<string>): stri
   do {
     const randomSuffix = crypto.randomBytes(2).toString("hex");
     candidate = `${prefix}-${randomSuffix}`;
-  } while (existingIds.has(candidate));
+  } while (existingIds.includes(candidate));
   return candidate;
 }
 
@@ -279,22 +279,20 @@ export function extractExistingFunctionsInfo(
       ? normalizeAndValidate(configFunctions)
       : [];
 
-  const existingKitIds = new Set<string>();
-  const existingCodebases = new Set<string>();
-  const existingInstanceIds = new Set<string>();
+  const existingKitIds: string[] = [];
+  const existingCodebases: string[] = [];
+  const existingInstanceIds: string[] = [];
 
   for (const c of existingFunctions) {
     if (isKitConfig(c)) {
       if (c.kit) {
-        existingKitIds.add(c.kit);
+        existingKitIds.push(c.kit);
       }
       if (c.instances) {
-        for (const instId of Object.keys(c.instances)) {
-          existingInstanceIds.add(instId);
-        }
+        existingInstanceIds.push(...Object.keys(c.instances));
       }
     } else if (c.codebase) {
-      existingCodebases.add(c.codebase);
+      existingCodebases.push(c.codebase);
     }
   }
 
@@ -311,22 +309,22 @@ export function extractExistingFunctionsInfo(
  */
 export async function promptKitInstanceId(
   baseKitId: string,
-  existingInstanceIds: Set<string>,
-  existingCodebases: Set<string>,
+  existingInstanceIds: string[],
+  existingCodebases: string[],
   nonInteractive?: boolean,
   customInstanceId?: string,
 ): Promise<string> {
-  const instanceCollisions = new Set([...existingInstanceIds, ...existingCodebases]);
+  const instanceCollisions = [...existingInstanceIds, ...existingCodebases];
   const defaultInstanceId = generateUniqueId(baseKitId, instanceCollisions);
 
   if (customInstanceId) {
     validateKitInstanceId(customInstanceId);
-    if (existingInstanceIds.has(customInstanceId)) {
+    if (existingInstanceIds.includes(customInstanceId)) {
       throw new FirebaseError(
         `functions kit instance ID must be unique across all kits, but '${customInstanceId}' was used more than once.`,
       );
     }
-    if (existingCodebases.has(customInstanceId)) {
+    if (existingCodebases.includes(customInstanceId)) {
       throw new FirebaseError(
         `functions codebase name and kit instance ID must be mutually exclusive, but '${customInstanceId}' was used as both a codebase name and a kit instance ID.`,
       );
@@ -344,10 +342,10 @@ export async function promptKitInstanceId(
       } catch (err: unknown) {
         return getErrMsg(err);
       }
-      if (existingInstanceIds.has(val)) {
+      if (existingInstanceIds.includes(val)) {
         return `functions kit instance ID must be unique across all kits, but '${val}' was used more than once.`;
       }
-      if (existingCodebases.has(val)) {
+      if (existingCodebases.includes(val)) {
         return `functions codebase name and kit instance ID must be mutually exclusive, but '${val}' was used as both a codebase name and a kit instance ID.`;
       }
       return true;
@@ -355,12 +353,12 @@ export async function promptKitInstanceId(
   });
 
   validateKitInstanceId(instanceId);
-  if (existingInstanceIds.has(instanceId)) {
+  if (existingInstanceIds.includes(instanceId)) {
     throw new FirebaseError(
       `functions kit instance ID must be unique across all kits, but '${instanceId}' was used more than once.`,
     );
   }
-  if (existingCodebases.has(instanceId)) {
+  if (existingCodebases.includes(instanceId)) {
     throw new FirebaseError(
       `functions codebase name and kit instance ID must be mutually exclusive, but '${instanceId}' was used as both a codebase name and a kit instance ID.`,
     );
@@ -374,7 +372,7 @@ export async function promptKitInstanceId(
  */
 export async function promptKitId(
   packageName: string,
-  existingKitIds: Set<string>,
+  existingKitIds: string[],
   nonInteractive?: boolean,
   customKitId?: string,
 ): Promise<string> {
@@ -383,7 +381,7 @@ export async function promptKitId(
 
   if (customKitId) {
     validateKit(customKitId);
-    if (existingKitIds.has(customKitId)) {
+    if (existingKitIds.includes(customKitId)) {
       throw new FirebaseError(
         `functions.kit must be unique but '${customKitId}' was used more than once.`,
       );
@@ -401,7 +399,7 @@ export async function promptKitId(
       } catch (err: unknown) {
         return getErrMsg(err);
       }
-      if (existingKitIds.has(val)) {
+      if (existingKitIds.includes(val)) {
         return `functions.kit must be unique but '${val}' was used more than once.`;
       }
       return true;
@@ -409,7 +407,7 @@ export async function promptKitId(
   });
 
   validateKit(kitId);
-  if (existingKitIds.has(kitId)) {
+  if (existingKitIds.includes(kitId)) {
     throw new FirebaseError(`functions.kit must be unique but '${kitId}' was used more than once.`);
   }
 

--- a/src/functions/kits/install.ts
+++ b/src/functions/kits/install.ts
@@ -109,6 +109,7 @@ export interface InstallKitOrInstanceOptions {
   project?: string;
   projectId?: string;
   rc?: RC;
+  skipReport?: boolean;
 }
 
 export interface InstallKitOrInstanceResult {
@@ -136,6 +137,7 @@ export interface ExistingKitInstallOptions {
   rc?: RC;
   instanceId?: string;
   seedEnv?: KitInstanceEnvSeed;
+  skipReport?: boolean;
 }
 
 export interface PromptAndWriteKitParamsOptions {
@@ -1071,6 +1073,17 @@ export async function addKitInstanceOrConfigureProject(
       );
     }
     absConfigDirPath = options.config.path(configDirPath);
+    if (options.seedEnv?.envs && Object.keys(options.seedEnv.envs).length > 0) {
+      await fs.ensureDir(absConfigDirPath);
+      seedKitInstanceEnv({
+        configDir: absConfigDirPath,
+        functionsSource: options.config.path(existingKit.source),
+        projectDir: options.config.projectDir,
+        projectId: options.seedEnv.projectId,
+        projectAlias: options.seedEnv.projectAlias,
+        envs: options.seedEnv.envs,
+      });
+    }
   } else {
     throw new FirebaseError(`Unexpected action '${String(action)}' for kit installation.`);
   }
@@ -1118,14 +1131,16 @@ export async function addKitInstanceOrConfigureProject(
     );
   }
 
-  await printKitFirstDeployReport({
-    config: options.config,
-    project: options.project,
-    projectId: options.projectId,
-    instanceId,
-    absSourcePath,
-    preDiscoveredBuild: discoveredBuild,
-  });
+  if (!options.skipReport) {
+    await printKitFirstDeployReport({
+      config: options.config,
+      project: options.project,
+      projectId: options.projectId,
+      instanceId,
+      absSourcePath,
+      preDiscoveredBuild: discoveredBuild,
+    });
+  }
 
   return {
     action: resultAction,
@@ -1344,14 +1359,16 @@ export async function installKitOrInstance(
   });
 
   logLabeledSuccess("functions", `Function kit ${clc.bold(kitId)} successfully installed.`);
-  await printKitFirstDeployReport({
-    config: options.config,
-    project: options.project,
-    projectId: options.projectId,
-    instanceId,
-    absSourcePath,
-    preDiscoveredBuild: discoveredBuild,
-  });
+  if (!options.skipReport) {
+    await printKitFirstDeployReport({
+      config: options.config,
+      project: options.project,
+      projectId: options.projectId,
+      instanceId,
+      absSourcePath,
+      preDiscoveredBuild: discoveredBuild,
+    });
+  }
 
   return {
     action: "installedKit",


### PR DESCRIPTION
### Description
- Supports `seedEnv` in `addKitInstanceOrConfigureProject` when configuring an existing kit instance for an environment/project.
- Ensures environment variables can be seeded into `.env.<projectId>` when adding or configuring kit instances programmatically.

### Scenarios Tested
- Added unit test in `src/functions/kits/install.spec.ts` verifying `seedEnv` writes `.env.<projectId>` during existing instance configuration.
- Ran full test suite in `src/functions/kits/install.spec.ts`.

### Sample Commands
- `npm test`
