### PR TITLE
fix(functions): Update index-kit-migration.ts template

### DIFF
--- a/templates/init/functions/typescript/index-kit-migration.ts
+++ b/templates/init/functions/typescript/index-kit-migration.ts
@@ -43,6 +43,8 @@ setGlobalOptions({
     ? Number(process.env.EXT_MIGRATED_SYSTEM_MININSTANCES)
     : undefined,
   ingressSettings: (process.env.EXT_MIGRATED_SYSTEM_INGRESSSETTINGS as IngressSetting) ?? undefined,
+  // Parses a comma-separated string of key:value pairs into a key-value object
+  // (e.g. "key1:value1,key2:value2" -> { key1: "value1", key2: "value2" }).
   labels: process.env.EXT_MIGRATED_SYSTEM_LABELS
     ? process.env.EXT_MIGRATED_SYSTEM_LABELS.split(",").reduce<Record<string, string> | undefined>(
         (acc, curr) => {

--- a/templates/init/functions/typescript/index-kit-migration.ts
+++ b/templates/init/functions/typescript/index-kit-migration.ts
@@ -31,7 +31,10 @@ setGlobalOptions({
     ? Number(process.env.EXT_MIGRATED_SYSTEM_TIMEOUTSECONDS)
     : undefined,
   vpcConnectorEgressSettings:
-    (process.env.EXT_MIGRATED_SYSTEM_VPCCONNECTOREGRESSSETTINGS as VpcEgressSetting) ?? undefined,
+    process.env.EXT_MIGRATED_SYSTEM_VPCCONNECTOREGRESSSETTINGS &&
+    process.env.EXT_MIGRATED_SYSTEM_VPCCONNECTOREGRESSSETTINGS !== "VPC_CONNECTOR_EGRESS_SETTINGS_UNSPECIFIED"
+      ? (process.env.EXT_MIGRATED_SYSTEM_VPCCONNECTOREGRESSSETTINGS as VpcEgressSetting)
+      : undefined,
   vpcConnector: process.env.EXT_MIGRATED_SYSTEM_VPCCONNECTOR ?? undefined,
   maxInstances: process.env.EXT_MIGRATED_SYSTEM_MAXINSTANCES
     ? Number(process.env.EXT_MIGRATED_SYSTEM_MAXINSTANCES)
@@ -41,7 +44,18 @@ setGlobalOptions({
     : undefined,
   ingressSettings: (process.env.EXT_MIGRATED_SYSTEM_INGRESSSETTINGS as IngressSetting) ?? undefined,
   labels: process.env.EXT_MIGRATED_SYSTEM_LABELS
-    ? (JSON.parse(process.env.EXT_MIGRATED_SYSTEM_LABELS) as Record<string, string>)
+    ? process.env.EXT_MIGRATED_SYSTEM_LABELS.split(",").reduce<Record<string, string> | undefined>(
+        (acc, curr) => {
+          const [key, ...values] = curr.split(":");
+          const trimmedKey = key?.trim();
+          if (trimmedKey && values.length > 0) {
+            acc = acc ?? {};
+            acc[trimmedKey] = values.join(":").trim();
+          }
+          return acc;
+        },
+        undefined,
+      )
     : undefined,
 });
 


### PR DESCRIPTION
### Description

After testing a deploy with variables derived from ext:export, a few bugs were caught.

* labels are defined as a string, splitting the key values pairs in a "key1:value,key2:value" format. We now convert the values into a Record<string,string> based on that format instead of expecting a JSON string.
* If there is no vpc connector egress setting defined, ext:export will populate the value with "VPC_CONNECTOR_EGRESS_SETTINGS_UNSPECIFIED". Now we add a check for this case.

### Scenarios Tested

1. Configured a firestore to bigquery extension to have labels in their system parameters
2. Ran `firebase functions:kits:install --package @firebase-function-kits/firestore-bigquery-export@0.0.2-rc.1 --no-configure`
3. `ext:export --mode functions ..` to copy the extension env to the kit instance config directory
4. (Had to manually resolve some deps to get this working, such as using peer dependencies for firebase-functions).
5. `firebase deploy --only functions:instance-id`