### PR TITLE
Alias handling in functions:kits:uninstall

### DIFF
--- a/src/commands/functions-kits-uninstall.ts
+++ b/src/commands/functions-kits-uninstall.ts
@@ -134,7 +134,7 @@ async function handleInstance(options: Options, config: Config): Promise<void> {
   );
   if (envFilesWhichAliasToProject.length > 1) {
     throw new FirebaseError(
-      `Instance ${instanceId} contains multiple .env files which ambiguously resolve to the current project ${envFileNames.map((s) => ".env." + s).join(",")}`,
+      `Instance ${instanceId} contains multiple .env files which ambiguously resolve to the current project ${envFilesWhichAliasToProject.map((s) => ".env." + s).join(", ")}`,
     );
   }
   if (envFilesWhichAliasToProject.length === 1) {
@@ -220,7 +220,7 @@ async function uninstallProjectInstance(
 ): Promise<void> {
   const projectId = options.rc?.resolveAlias(envName) || envName;
   const envFilePath = join(kitInstancePath, `.env.${envName}`);
-  if (config.projectFileExists(envFilePath)) {
+  if (!config.projectFileExists(envFilePath)) {
     throw new FirebaseError(
       `Expected to clean up project kit instance .env file at ${envFilePath}, but it doesn't exist.`,
     );

--- a/src/commands/functions-kits-uninstall.ts
+++ b/src/commands/functions-kits-uninstall.ts
@@ -205,11 +205,9 @@ async function uninstallInstance(
 
 /*
  * Remove the .env.<projectAlias> file and deployed Function for a specific project instance
-
- * @param configPath: project-relative function-kits/<kitId>/config-<instanceId>
- * @param projectId: must be specified, since configPath is user-overridable
- * #param filesystemId: the project reference in name of .env file, either the project id or from .firebaserc aliases 
+ * @param envName: the project reference in name of .env file, either the project id or from .firebaserc aliases 
  * @param instanceId: must be specified, since configPath is user-overridable
+ * @param kitInstancePath: project-relative function-kits/<kitId>/config-<instanceId> 
  */
 async function uninstallProjectInstance(
   options: Options,

--- a/src/commands/functions-kits-uninstall.ts
+++ b/src/commands/functions-kits-uninstall.ts
@@ -83,24 +83,14 @@ async function handleInstance(options: Options, config: Config): Promise<void> {
     `Kit ${kitForInstance.kit} uninstall mode: conservativeDeletion=${conservativeDeletion}`,
   );
 
-  const envFileNames: string[] = [];
-  const projectNamesInEnvs: string[] = [];
   const configDirContents = config.lsProjectDir(instanceConfigDirPath);
-  const fileNames = configDirContents.filter((f) => f.isFile()).map((f) => f.name);
-  for (const fileName of fileNames) {
-    if (!fileName.startsWith(".env.")) {
-      continue;
-    }
-    envFileNames.push(fileName.slice(".env.".length));
-  }
+  const envFileNames = configDirContents
+    .filter((f) => f.isFile() && f.name.startsWith(".env."))
+    .map((f) => f.name.slice(".env.".length));
   const aliasToProjectMappings = getAliasesToProjects(config);
-  for (const envName of envFileNames) {
-    if (aliasToProjectMappings[envName]) {
-      projectNamesInEnvs.push(aliasToProjectMappings[envName]);
-    } else {
-      projectNamesInEnvs.push(envName);
-    }
-  }
+  const projectNamesInEnvs = envFileNames.map(
+    (envName) => aliasToProjectMappings[envName] || envName,
+  );
 
   // Cases:
   // - error if instance config dir contains projects but doesn't contain current project
@@ -219,7 +209,7 @@ async function uninstallProjectInstanceByAlias(
   projectAlias: string,
   instanceId: string,
   kitInstancePath: string,
-) {
+): Promise<void> {
   const aliasToProjectMappings = getAliasesToProjects(config);
   const projectId = aliasToProjectMappings[projectAlias] || projectAlias;
   await uninstallProjectInstance(
@@ -353,12 +343,13 @@ function getAliasesToProjects(config: Config): Record<string, string> {
     json: true,
     fallback: {},
   });
-  if ("projects" in firebaserc && typeof firebaserc.projects === "object") {
-    const asStrings: Record<string, string> = {};
-    for (const [project, alias] of Object.entries(firebaserc.projects)) {
-      asStrings[String(alias)] = project;
-    }
-    return asStrings;
+  if (!("projects" in firebaserc) || typeof firebaserc.projects !== "object") {
+    return {};
   }
-  return {};
+  const projects = firebaserc.projects;
+  const asStrings: Record<string, string> = {};
+  for (const [alias, project] of Object.entries(projects)) {
+    asStrings[alias] = String(project);
+  }
+  return asStrings;
 }

--- a/src/commands/functions-kits-uninstall.ts
+++ b/src/commands/functions-kits-uninstall.ts
@@ -205,9 +205,9 @@ async function uninstallInstance(
 
 /*
  * Remove the .env.<projectAlias> file and deployed Function for a specific project instance
- * @param envName: the project reference in name of .env file, either the project id or from .firebaserc aliases 
+ * @param envName: the project reference in name of .env file, either the project id or from .firebaserc aliases
  * @param instanceId: must be specified, since configPath is user-overridable
- * @param kitInstancePath: project-relative function-kits/<kitId>/config-<instanceId> 
+ * @param kitInstancePath: project-relative function-kits/<kitId>/config-<instanceId>
  */
 async function uninstallProjectInstance(
   options: Options,

--- a/src/commands/functions-kits-uninstall.ts
+++ b/src/commands/functions-kits-uninstall.ts
@@ -83,14 +83,23 @@ async function handleInstance(options: Options, config: Config): Promise<void> {
     `Kit ${kitForInstance.kit} uninstall mode: conservativeDeletion=${conservativeDeletion}`,
   );
 
-  const projectsWithConfigs: string[] = [];
+  const envFileNames: string[] = [];
+  const projectNamesInEnvs: string[] = [];
   const configDirContents = config.lsProjectDir(instanceConfigDirPath);
   const fileNames = configDirContents.filter((f) => f.isFile()).map((f) => f.name);
   for (const fileName of fileNames) {
     if (!fileName.startsWith(".env.")) {
       continue;
     }
-    projectsWithConfigs.push(fileName.slice(".env.".length));
+    envFileNames.push(fileName.slice(".env.".length));
+  }
+  const aliasToProjectMappings = getAliasesToProjects(config);
+  for (const envName of envFileNames) {
+    if (aliasToProjectMappings[envName]) {
+      projectNamesInEnvs.push(aliasToProjectMappings[envName]);
+    } else {
+      projectNamesInEnvs.push(envName);
+    }
   }
 
   // Cases:
@@ -100,12 +109,12 @@ async function handleInstance(options: Options, config: Config): Promise<void> {
   // - current project is only project for an instance, so just tear down the instance
   // - only remove .env and function
 
-  if (projectsWithConfigs.length > 0 && !projectsWithConfigs.includes(projectId)) {
+  if (projectNamesInEnvs.length > 0 && !projectNamesInEnvs.includes(projectId)) {
     throw new FirebaseError(
       `Instance at ${instanceConfigDirPath} contains no .env file for current project`,
     );
   }
-  if (projectsWithConfigs.length === 0 || projectsWithConfigs.length === 1) {
+  if (envFileNames.length === 0 || envFileNames.length === 1) {
     if (Object.keys(kitForInstance.instances).length > 1) {
       await uninstallInstance(
         options,
@@ -130,7 +139,20 @@ async function handleInstance(options: Options, config: Config): Promise<void> {
     await uninstallKit(options, config, kitForInstance);
     return;
   }
-  await uninstallProjectInstance(options, config, projectId, instanceId, instanceConfigDirPath);
+  let filesystemNameForProject = projectId;
+  for (const [alias, project] of Object.entries(aliasToProjectMappings)) {
+    if (project === projectId) {
+      filesystemNameForProject = alias;
+    }
+  }
+  await uninstallProjectInstance(
+    options,
+    config,
+    projectId,
+    filesystemNameForProject,
+    instanceId,
+    instanceConfigDirPath,
+  );
 }
 
 /*
@@ -155,8 +177,14 @@ async function uninstallInstance(
     if (!fileName.startsWith(".env.")) {
       continue;
     }
-    const projectId = fileName.replace(new RegExp("^.env."), "");
-    await uninstallProjectInstance(options, config, projectId, instanceId, instanceConfigDirPath);
+    const projectIdOrAlias = fileName.replace(new RegExp("^.env."), "");
+    await uninstallProjectInstanceByAlias(
+      options,
+      config,
+      projectIdOrAlias,
+      instanceId,
+      instanceConfigDirPath,
+    );
   }
   if (!onlyDeleteEmpty || configDirEmpty(config, instanceConfigDirPath)) {
     config.deleteProjectDir(instanceConfigDirPath);
@@ -181,21 +209,46 @@ async function uninstallInstance(
   config.writeProjectFile("firebase.json", config.src);
 }
 
+/**
+ * Invoke uninstallProjectInstance when only the instance's .env file name is known
+ * (from doing a directory walk), checking .firebaserc for whether name is a known project alias.
+ */
+async function uninstallProjectInstanceByAlias(
+  options: Options,
+  config: Config,
+  projectAlias: string,
+  instanceId: string,
+  kitInstancePath: string,
+) {
+  const aliasToProjectMappings = getAliasesToProjects(config);
+  const projectId = aliasToProjectMappings[projectAlias] || projectAlias;
+  await uninstallProjectInstance(
+    options,
+    config,
+    projectId,
+    projectAlias,
+    instanceId,
+    kitInstancePath,
+  );
+}
+
 /*
- * Remove the .env.<projectId> file and deployed Function for a specific project instance
+ * Remove the .env.<projectAlias> file and deployed Function for a specific project instance
 
  * @param configPath: project-relative function-kits/<kitId>/config-<instanceId>
  * @param projectId: must be specified, since configPath is user-overridable
+ * #param filesystemId: the project reference in name of .env file, either the project id or from .firebaserc aliases 
  * @param instanceId: must be specified, since configPath is user-overridable
  */
 async function uninstallProjectInstance(
   options: Options,
   config: Config,
   projectId: string,
+  filesystemId: string,
   instanceId: string,
   kitInstancePath: string,
 ): Promise<void> {
-  const envFilePath = join(kitInstancePath, `.env.${projectId}`);
+  const envFilePath = join(kitInstancePath, `.env.${filesystemId}`);
   const epFilters: EndpointFilter[] = [{ codebase: instanceId }];
   const deployContext: Context = { projectId: projectId, filters: epFilters };
   const deletionCount = await deleteFunctionsByEndpointFilters(deployContext, options);
@@ -292,4 +345,20 @@ function configDirEmpty(config: Config, projectRelativePath: string): boolean {
     return false;
   }
   return true;
+}
+
+// Reads .firebaserc for the project-to-alias mapping and reverses it
+function getAliasesToProjects(config: Config): Record<string, string> {
+  const firebaserc = config.readProjectFile(".firebaserc", {
+    json: true,
+    fallback: {},
+  });
+  if ("projects" in firebaserc && typeof firebaserc.projects === "object") {
+    const asStrings: Record<string, string> = {};
+    for (const [project, alias] of Object.entries(firebaserc.projects)) {
+      asStrings[String(alias)] = project;
+    }
+    return asStrings;
+  }
+  return {};
 }

--- a/src/commands/functions-kits-uninstall.ts
+++ b/src/commands/functions-kits-uninstall.ts
@@ -87,9 +87,8 @@ async function handleInstance(options: Options, config: Config): Promise<void> {
   const envFileNames = configDirContents
     .filter((f) => f.isFile() && f.name.startsWith(".env."))
     .map((f) => f.name.slice(".env.".length));
-  const aliasToProjectMappings = getAliasesToProjects(config);
-  const projectNamesInEnvs = envFileNames.map(
-    (envName) => aliasToProjectMappings[envName] || envName,
+  const projectNamesInEnvs = envFileNames.map((envName) =>
+    options.rc ? options.rc.resolveAlias(envName) : envName,
   );
 
   // Cases:
@@ -130,15 +129,20 @@ async function handleInstance(options: Options, config: Config): Promise<void> {
     return;
   }
   let filesystemNameForProject = projectId;
-  for (const [alias, project] of Object.entries(aliasToProjectMappings)) {
-    if (project === projectId) {
-      filesystemNameForProject = alias;
-    }
+  const envFilesWhichAliasToProject = envFileNames.filter(
+    (name) => (options.rc?.resolveAlias(name) || name) === projectId,
+  );
+  if (envFilesWhichAliasToProject.length > 1) {
+    throw new FirebaseError(
+      `Instance ${instanceId} contains multiple .env files which ambiguously resolve to the current project ${envFileNames.map((s) => ".env." + s).join(",")}`,
+    );
+  }
+  if (envFilesWhichAliasToProject.length === 1) {
+    filesystemNameForProject = envFilesWhichAliasToProject[0];
   }
   await uninstallProjectInstance(
     options,
     config,
-    projectId,
     filesystemNameForProject,
     instanceId,
     instanceConfigDirPath,
@@ -167,8 +171,8 @@ async function uninstallInstance(
     if (!fileName.startsWith(".env.")) {
       continue;
     }
-    const projectIdOrAlias = fileName.replace(new RegExp("^.env."), "");
-    await uninstallProjectInstanceByAlias(
+    const projectIdOrAlias = fileName.slice(".env.".length);
+    await uninstallProjectInstance(
       options,
       config,
       projectIdOrAlias,
@@ -199,29 +203,6 @@ async function uninstallInstance(
   config.writeProjectFile("firebase.json", config.src);
 }
 
-/**
- * Invoke uninstallProjectInstance when only the instance's .env file name is known
- * (from doing a directory walk), checking .firebaserc for whether name is a known project alias.
- */
-async function uninstallProjectInstanceByAlias(
-  options: Options,
-  config: Config,
-  projectAlias: string,
-  instanceId: string,
-  kitInstancePath: string,
-): Promise<void> {
-  const aliasToProjectMappings = getAliasesToProjects(config);
-  const projectId = aliasToProjectMappings[projectAlias] || projectAlias;
-  await uninstallProjectInstance(
-    options,
-    config,
-    projectId,
-    projectAlias,
-    instanceId,
-    kitInstancePath,
-  );
-}
-
 /*
  * Remove the .env.<projectAlias> file and deployed Function for a specific project instance
 
@@ -233,12 +214,17 @@ async function uninstallProjectInstanceByAlias(
 async function uninstallProjectInstance(
   options: Options,
   config: Config,
-  projectId: string,
-  filesystemId: string,
+  envName: string,
   instanceId: string,
   kitInstancePath: string,
 ): Promise<void> {
-  const envFilePath = join(kitInstancePath, `.env.${filesystemId}`);
+  const projectId = options.rc?.resolveAlias(envName) || envName;
+  const envFilePath = join(kitInstancePath, `.env.${envName}`);
+  if (config.projectFileExists(envFilePath)) {
+    throw new FirebaseError(
+      `Expected to clean up project kit instance .env file at ${envFilePath}, but it doesn't exist.`,
+    );
+  }
   const epFilters: EndpointFilter[] = [{ codebase: instanceId }];
   const deployContext: Context = { projectId: projectId, filters: epFilters };
   const deletionCount = await deleteFunctionsByEndpointFilters(deployContext, options);
@@ -335,21 +321,4 @@ function configDirEmpty(config: Config, projectRelativePath: string): boolean {
     return false;
   }
   return true;
-}
-
-// Reads .firebaserc for the project-to-alias mapping and reverses it
-function getAliasesToProjects(config: Config): Record<string, string> {
-  const firebaserc = config.readProjectFile(".firebaserc", {
-    json: true,
-    fallback: {},
-  });
-  if (!("projects" in firebaserc) || typeof firebaserc.projects !== "object") {
-    return {};
-  }
-  const projects = firebaserc.projects;
-  const asStrings: Record<string, string> = {};
-  for (const [alias, project] of Object.entries(projects)) {
-    asStrings[alias] = String(project);
-  }
-  return asStrings;
 }


### PR DESCRIPTION
Kind of a mess of a PR.

Changes:
1) the base-level function which handles function deletion and filesystem changes gets a new arg which specifies the filesystem location instead of just assuming project id
2) in the --instance handler, we respect .firebaserc aliases when determining if the instance contains the current project in its envs
3) also in the --instance handler, if we need to directly call the project-level deletion function in (1), we derive the value of the new arg from .firebase rc and currnet project
4) the "nuke an entire instance" helper only has access to the filesystem names of the .env files in the instance, so it needs to do the reverse: check .firebaserc to figure out what the project ids are for those .env file names. this is redundant if you're coming from --instance because of all the work we did above, but necessary if you're coming from --kit