### PR TITLE
feat: dynamically resolve and save kit SDK dependencies

### DIFF
--- a/src/functions/kits/install.spec.ts
+++ b/src/functions/kits/install.spec.ts
@@ -32,6 +32,7 @@ import {
   addKitInstanceOrConfigureProject,
   installKitOrInstance,
   promptAndWriteKitParams,
+  getKitPackagesToSave,
   TemplateType,
 } from "./install";
 import * as env from "./env";
@@ -992,7 +993,10 @@ describe("functions/kits/install", () => {
         projectDir: "/mock/project",
         src: {},
         path: (rel: string) => path.join("/mock/project", rel),
-        askWriteProjectFile: sinon.stub().resolves(),
+        askWriteProjectFile: (file: string, content: unknown) => {
+          writtenFiles[file] = content;
+          return Promise.resolve();
+        },
         writeProjectFile: (file: string, content: unknown) => {
           writtenFiles[file] = content;
         },
@@ -1009,6 +1013,10 @@ describe("functions/kits/install", () => {
       expect(paths.configDirPath).to.equal("function-kits/my-kit/config-inst1");
       expect(seedKitInstanceEnvStub).to.not.have.been.called;
       expect(writtenFiles["firebase.json"]).to.exist;
+      expect(writtenFiles["function-kits/my-kit/source/package.json"]).to.deep.include({
+        name: "my-kit-wrapper",
+        dependencies: {},
+      });
     });
 
     it("should scaffold files, seed .env.<project-id>, and add kit to config when seedEnv is provided", async () => {
@@ -1482,7 +1490,7 @@ describe("functions/kits/install", () => {
     it("should run npm install and npm run build without --ignore-scripts for first-party kit", async () => {
       await buildAndInstallKit("/abs/path", "@firebase-function-kits/my-kit", false);
 
-      expect(wrapSpawnStub).to.have.been.calledTwice;
+      expect(wrapSpawnStub).to.have.been.calledThrice;
       expect(wrapSpawnStub.firstCall).to.have.been.calledWith(
         "npm",
         ["install", "@firebase-function-kits/my-kit", "--save-prefix=^"],
@@ -1490,15 +1498,16 @@ describe("functions/kits/install", () => {
       );
       expect(wrapSpawnStub.secondCall).to.have.been.calledWith(
         "npm",
-        ["run", "build"],
+        ["install", "firebase-functions@latest", "--save-prefix=^"],
         "/abs/path",
       );
+      expect(wrapSpawnStub.thirdCall).to.have.been.calledWith("npm", ["run", "build"], "/abs/path");
     });
 
     it("should run npm install with --ignore-scripts for third-party kit", async () => {
       await buildAndInstallKit("/abs/path", "third-party-kit", true);
 
-      expect(wrapSpawnStub).to.have.been.calledTwice;
+      expect(wrapSpawnStub).to.have.been.calledThrice;
       expect(wrapSpawnStub.firstCall).to.have.been.calledWith(
         "npm",
         ["install", "third-party-kit", "--save-prefix=^", "--ignore-scripts"],
@@ -1506,9 +1515,10 @@ describe("functions/kits/install", () => {
       );
       expect(wrapSpawnStub.secondCall).to.have.been.calledWith(
         "npm",
-        ["run", "build"],
+        ["install", "firebase-functions@latest", "--save-prefix=^"],
         "/abs/path",
       );
+      expect(wrapSpawnStub.thirdCall).to.have.been.calledWith("npm", ["run", "build"], "/abs/path");
     });
 
     it("should throw FirebaseError if npm install fails", async () => {
@@ -1520,14 +1530,163 @@ describe("functions/kits/install", () => {
       );
     });
 
+    it("should throw FirebaseError if saving SDK dependencies fails", async () => {
+      wrapSpawnStub
+        .withArgs("npm", ["install", "firebase-functions@latest", "--save-prefix=^"], "/abs/path")
+        .rejects(new Error("ERESOLVE peer dependency conflict"));
+
+      await expect(buildAndInstallKit("/abs/path", "my-kit", false)).to.be.rejectedWith(
+        FirebaseError,
+        /Failed to install required SDK dependencies/,
+      );
+    });
+
     it("should throw FirebaseError if typescript build fails", async () => {
-      wrapSpawnStub.onFirstCall().resolves();
-      wrapSpawnStub.onSecondCall().rejects(new Error("tsc build error"));
+      wrapSpawnStub
+        .withArgs("npm", ["run", "build"], "/abs/path")
+        .rejects(new Error("tsc build error"));
 
       await expect(buildAndInstallKit("/abs/path", "my-kit", false)).to.be.rejectedWith(
         FirebaseError,
         /TypeScript build failed: tsc build error/,
       );
+    });
+  });
+
+  describe("getKitPackagesToSave", () => {
+    function mockFs(files: Record<string, unknown>): void {
+      (fs.pathExists as sinon.SinonStub).callsFake((p: string) => Promise.resolve(p in files));
+      (fs.readJson as sinon.SinonStub).callsFake((p: string) => {
+        const val = files[p];
+        if (val instanceof Error) {
+          return Promise.reject(val);
+        }
+        return Promise.resolve(val || {});
+      });
+    }
+
+    it("should resolve installed versions from package-lock.json when hoisted", async () => {
+      mockFs({
+        "/mock/src/package-lock.json": {
+          packages: {
+            "node_modules/@scope/my-kit": {
+              peerDependencies: {
+                "firebase-admin": "^14.0.0",
+                "firebase-functions": "^7.0.0",
+              },
+            },
+            "node_modules/firebase-admin": { version: "14.3.0" },
+            "node_modules/firebase-functions": { version: "7.3.2" },
+          },
+        },
+      });
+
+      const packagesToSave = await getKitPackagesToSave("/mock/src", "@scope/my-kit");
+
+      expect(packagesToSave).to.deep.equal(["firebase-functions@^7.3.2", "firebase-admin@^14.3.0"]);
+    });
+
+    it("should resolve declared versions from package-lock.json when packages are not hoisted", async () => {
+      mockFs({
+        "/mock/src/package-lock.json": {
+          packages: {
+            "node_modules/@scope/my-kit": {
+              peerDependencies: {
+                "firebase-admin": "^14.2.0",
+                "firebase-functions": "^7.1.0",
+              },
+            },
+          },
+        },
+      });
+
+      const packagesToSave = await getKitPackagesToSave("/mock/src", "@scope/my-kit");
+
+      expect(packagesToSave).to.deep.equal(["firebase-functions@^7.1.0", "firebase-admin@^14.2.0"]);
+    });
+
+    it("should omit firebase-admin when not declared, even if firebase-admin is present in package-lock.json", async () => {
+      mockFs({
+        "/mock/src/package-lock.json": {
+          packages: {
+            "node_modules/@scope/my-kit": {
+              dependencies: {
+                "firebase-functions": "^7.2.0",
+              },
+            },
+            "node_modules/firebase-admin": { version: "14.3.0" },
+            "node_modules/firebase-functions": { version: "7.2.0" },
+          },
+        },
+      });
+
+      const packagesToSave = await getKitPackagesToSave("/mock/src", "@scope/my-kit");
+
+      expect(packagesToSave).to.deep.equal(["firebase-functions@^7.2.0"]);
+    });
+
+    it("should fall back to firebase-functions@latest when functions is undeclared and not installed", async () => {
+      mockFs({
+        "/mock/src/package-lock.json": {
+          packages: {
+            "node_modules/@scope/my-kit": {
+              dependencies: {},
+            },
+          },
+        },
+      });
+
+      const packagesToSave = await getKitPackagesToSave("/mock/src", "@scope/my-kit");
+
+      expect(packagesToSave).to.deep.equal(["firebase-functions@latest"]);
+    });
+
+    it("should fall back to reading node_modules package.json when lockfile is missing", async () => {
+      mockFs({
+        "/mock/src/node_modules/@scope/my-kit/package.json": {
+          peerDependencies: {
+            "firebase-admin": "^14.1.0",
+            "firebase-functions": "^7.3.2",
+          },
+        },
+      });
+
+      const packagesToSave = await getKitPackagesToSave("/mock/src", "@scope/my-kit");
+
+      expect(packagesToSave).to.deep.equal(["firebase-functions@^7.3.2", "firebase-admin@^14.1.0"]);
+    });
+
+    it("should preserve range and >= syntax when falling back to node_modules package.json", async () => {
+      mockFs({
+        "/mock/src/node_modules/@scope/my-kit/package.json": {
+          peerDependencies: {
+            "firebase-admin": ">=13.0.0 <15.0.0",
+            "firebase-functions": ">=7.0.0",
+          },
+        },
+      });
+
+      const packagesToSave = await getKitPackagesToSave("/mock/src", "@scope/my-kit");
+
+      expect(packagesToSave).to.deep.equal([
+        "firebase-functions@>=7.0.0",
+        "firebase-admin@>=13.0.0 <15.0.0",
+      ]);
+    });
+
+    it("should fall back gracefully to node_modules when lockfile contains invalid JSON", async () => {
+      mockFs({
+        "/mock/src/package-lock.json": new Error("Invalid JSON"),
+        "/mock/src/node_modules/@scope/my-kit/package.json": {
+          dependencies: {
+            "firebase-functions": "^7.0.0",
+          },
+        },
+      });
+
+      const packagesToSave = await getKitPackagesToSave("/mock/src", "@scope/my-kit");
+
+      expect(packagesToSave).to.deep.equal(["firebase-functions@^7.0.0"]);
     });
   });
 
@@ -2734,13 +2893,18 @@ describe("functions/kits/install", () => {
         configDirPath: "function-kits/firestore-bigquery-export/config-firestore-bigquery-export",
       });
 
-      expect(wrapSpawnStub).to.have.been.calledTwice;
+      expect(wrapSpawnStub).to.have.been.calledThrice;
       expect(wrapSpawnStub.firstCall).to.have.been.calledWith(
         "npm",
         ["install", "@firebase-function-kits/firestore-bigquery-export@1.0.0", "--save-prefix=^"],
         "/mock/project/function-kits/firestore-bigquery-export/source",
       );
       expect(wrapSpawnStub.secondCall).to.have.been.calledWith(
+        "npm",
+        ["install", "firebase-functions@latest", "--save-prefix=^"],
+        "/mock/project/function-kits/firestore-bigquery-export/source",
+      );
+      expect(wrapSpawnStub.thirdCall).to.have.been.calledWith(
         "npm",
         ["run", "build"],
         "/mock/project/function-kits/firestore-bigquery-export/source",

--- a/src/functions/kits/install.spec.ts
+++ b/src/functions/kits/install.spec.ts
@@ -33,6 +33,7 @@ import {
   installKitOrInstance,
   promptAndWriteKitParams,
   getKitPackagesToSave,
+  resolveSdkSpecifierToSave,
   TemplateType,
 } from "./install";
 import * as env from "./env";
@@ -82,6 +83,17 @@ describe("functions/kits/install", () => {
   afterEach(() => {
     sinon.restore();
   });
+
+  function mockFs(files: Record<string, unknown>): void {
+    (fs.pathExists as sinon.SinonStub).callsFake((p: string) => Promise.resolve(p in files));
+    (fs.readJson as sinon.SinonStub).callsFake((p: string) => {
+      const val = files[p];
+      if (val instanceof Error) {
+        return Promise.reject(val);
+      }
+      return Promise.resolve(val || {});
+    });
+  }
 
   describe("validateNpmPackageName", () => {
     it("should accept valid unscoped package names", () => {
@@ -153,6 +165,56 @@ describe("functions/kits/install", () => {
       expect(() => validateNpmPackageName("a".repeat(215))).to.throw(
         FirebaseError,
         /Invalid NPM package name/,
+      );
+    });
+  });
+
+  describe("resolveSdkSpecifierToSave", () => {
+    it("should preserve exact pins with = prefix", () => {
+      expect(resolveSdkSpecifierToSave("firebase-functions", "7.1.0", "7.1.0")).to.equal(
+        "firebase-functions@=7.1.0",
+      );
+      expect(resolveSdkSpecifierToSave("firebase-functions", "=7.1.0", "7.1.0")).to.equal(
+        "firebase-functions@=7.1.0",
+      );
+      expect(resolveSdkSpecifierToSave("firebase-functions", "v7.1.0", "7.1.0")).to.equal(
+        "firebase-functions@=7.1.0",
+      );
+      expect(resolveSdkSpecifierToSave("firebase-functions", "7.1.0")).to.equal(
+        "firebase-functions@=7.1.0",
+      );
+    });
+
+    it("should preserve tilde ranges anchored to installed version", () => {
+      expect(resolveSdkSpecifierToSave("firebase-functions", "~7.1.0", "7.1.2")).to.equal(
+        "firebase-functions@~7.1.2",
+      );
+      expect(resolveSdkSpecifierToSave("firebase-functions", "~7.1.0")).to.equal(
+        "firebase-functions@~7.1.0",
+      );
+    });
+
+    it("should anchor caret ranges to installed version with ^", () => {
+      expect(resolveSdkSpecifierToSave("firebase-functions", "^7.0.0", "7.3.2")).to.equal(
+        "firebase-functions@^7.3.2",
+      );
+    });
+
+    it("should anchor wide ranges to installed version with ^", () => {
+      expect(resolveSdkSpecifierToSave("firebase-functions", ">=7.0.0", "7.3.2")).to.equal(
+        "firebase-functions@^7.3.2",
+      );
+      expect(resolveSdkSpecifierToSave("firebase-functions", ">=7.0.0 <8.0.0", "7.3.2")).to.equal(
+        "firebase-functions@^7.3.2",
+      );
+    });
+
+    it("should preserve declared range when installed version is not available", () => {
+      expect(resolveSdkSpecifierToSave("firebase-functions", "^7.0.0")).to.equal(
+        "firebase-functions@^7.0.0",
+      );
+      expect(resolveSdkSpecifierToSave("firebase-functions", ">=7.0.0")).to.equal(
+        "firebase-functions@>=7.0.0",
       );
     });
   });
@@ -1487,6 +1549,34 @@ describe("functions/kits/install", () => {
   });
 
   describe("buildAndInstallKit", () => {
+    // Function kits must declare 'firebase-functions' as a dependency or peer dependency.
+    // Provide a mock package-lock.json with valid kit entries and installed SDK versions
+    // so tests can exercise installation logic (e.g. npm flags, scripts) against a valid kit baseline.
+    beforeEach(() => {
+      mockFs({
+        "/abs/path/package-lock.json": {
+          packages: {
+            "node_modules/@firebase-function-kits/my-kit": {
+              peerDependencies: {
+                "firebase-functions": "^7.0.0",
+              },
+            },
+            "node_modules/third-party-kit": {
+              peerDependencies: {
+                "firebase-functions": "^7.0.0",
+              },
+            },
+            "node_modules/my-kit": {
+              peerDependencies: {
+                "firebase-functions": "^7.0.0",
+              },
+            },
+            "node_modules/firebase-functions": { version: "7.3.2" },
+          },
+        },
+      });
+    });
+
     it("should run npm install and npm run build without --ignore-scripts for first-party kit", async () => {
       await buildAndInstallKit("/abs/path", "@firebase-function-kits/my-kit", false);
 
@@ -1498,7 +1588,7 @@ describe("functions/kits/install", () => {
       );
       expect(wrapSpawnStub.secondCall).to.have.been.calledWith(
         "npm",
-        ["install", "firebase-functions@latest", "--save-prefix=^"],
+        ["install", "firebase-functions@^7.3.2", "--save-prefix=^"],
         "/abs/path",
       );
       expect(wrapSpawnStub.thirdCall).to.have.been.calledWith("npm", ["run", "build"], "/abs/path");
@@ -1515,7 +1605,39 @@ describe("functions/kits/install", () => {
       );
       expect(wrapSpawnStub.secondCall).to.have.been.calledWith(
         "npm",
-        ["install", "firebase-functions@latest", "--save-prefix=^", "--ignore-scripts"],
+        ["install", "firebase-functions@^7.3.2", "--save-prefix=^", "--ignore-scripts"],
+        "/abs/path",
+      );
+      expect(wrapSpawnStub.thirdCall).to.have.been.calledWith("npm", ["run", "build"], "/abs/path");
+    });
+
+    it("should save multiple SDK dependencies when kit declares both functions and admin", async () => {
+      mockFs({
+        "/abs/path/package-lock.json": {
+          packages: {
+            "node_modules/@firebase-function-kits/my-kit": {
+              peerDependencies: {
+                "firebase-admin": "^14.0.0",
+                "firebase-functions": "^7.0.0",
+              },
+            },
+            "node_modules/firebase-admin": { version: "14.3.0" },
+            "node_modules/firebase-functions": { version: "7.3.2" },
+          },
+        },
+      });
+
+      await buildAndInstallKit("/abs/path", "@firebase-function-kits/my-kit", false);
+
+      expect(wrapSpawnStub).to.have.been.calledThrice;
+      expect(wrapSpawnStub.firstCall).to.have.been.calledWith(
+        "npm",
+        ["install", "@firebase-function-kits/my-kit", "--save-prefix=^"],
+        "/abs/path",
+      );
+      expect(wrapSpawnStub.secondCall).to.have.been.calledWith(
+        "npm",
+        ["install", "firebase-functions@^7.3.2", "firebase-admin@^14.3.0", "--save-prefix=^"],
         "/abs/path",
       );
       expect(wrapSpawnStub.thirdCall).to.have.been.calledWith("npm", ["run", "build"], "/abs/path");
@@ -1533,7 +1655,7 @@ describe("functions/kits/install", () => {
     it("should throw FirebaseError if saving SDK dependencies fails", async () => {
       const origError = new Error("ERESOLVE peer dependency conflict");
       wrapSpawnStub
-        .withArgs("npm", ["install", "firebase-functions@latest", "--save-prefix=^"], "/abs/path")
+        .withArgs("npm", ["install", "firebase-functions@^7.3.2", "--save-prefix=^"], "/abs/path")
         .rejects(origError);
 
       let err: unknown;
@@ -1562,17 +1684,6 @@ describe("functions/kits/install", () => {
   });
 
   describe("getKitPackagesToSave", () => {
-    function mockFs(files: Record<string, unknown>): void {
-      (fs.pathExists as sinon.SinonStub).callsFake((p: string) => Promise.resolve(p in files));
-      (fs.readJson as sinon.SinonStub).callsFake((p: string) => {
-        const val = files[p];
-        if (val instanceof Error) {
-          return Promise.reject(val);
-        }
-        return Promise.resolve(val || {});
-      });
-    }
-
     it("should resolve installed versions from package-lock.json when hoisted", async () => {
       mockFs({
         "/mock/src/package-lock.json": {
@@ -1633,7 +1744,7 @@ describe("functions/kits/install", () => {
       expect(packagesToSave).to.deep.equal(["firebase-functions@^7.2.0"]);
     });
 
-    it("should fall back to firebase-functions@latest when functions is undeclared and not installed", async () => {
+    it("should throw FirebaseError when functions is undeclared", async () => {
       mockFs({
         "/mock/src/package-lock.json": {
           packages: {
@@ -1644,9 +1755,10 @@ describe("functions/kits/install", () => {
         },
       });
 
-      const packagesToSave = await getKitPackagesToSave("/mock/src", "@scope/my-kit");
-
-      expect(packagesToSave).to.deep.equal(["firebase-functions@latest"]);
+      await expect(getKitPackagesToSave("/mock/src", "@scope/my-kit")).to.be.rejectedWith(
+        FirebaseError,
+        /Package '@scope\/my-kit' is not a valid Function Kit: it must declare 'firebase-functions'/,
+      );
     });
 
     it("should fall back to reading node_modules package.json when lockfile is missing", async () => {
@@ -1695,6 +1807,44 @@ describe("functions/kits/install", () => {
       const packagesToSave = await getKitPackagesToSave("/mock/src", "@scope/my-kit");
 
       expect(packagesToSave).to.deep.equal(["firebase-functions@^7.0.0"]);
+    });
+
+    it("should preserve exact pins when declared in package-lock.json", async () => {
+      mockFs({
+        "/mock/src/package-lock.json": {
+          packages: {
+            "node_modules/@scope/my-kit": {
+              peerDependencies: {
+                "firebase-functions": "7.1.0",
+              },
+            },
+            "node_modules/firebase-functions": { version: "7.1.0" },
+          },
+        },
+      });
+
+      const packagesToSave = await getKitPackagesToSave("/mock/src", "@scope/my-kit");
+
+      expect(packagesToSave).to.deep.equal(["firebase-functions@=7.1.0"]);
+    });
+
+    it("should preserve tilde ranges when declared in package-lock.json", async () => {
+      mockFs({
+        "/mock/src/package-lock.json": {
+          packages: {
+            "node_modules/@scope/my-kit": {
+              peerDependencies: {
+                "firebase-functions": "~7.1.0",
+              },
+            },
+            "node_modules/firebase-functions": { version: "7.1.3" },
+          },
+        },
+      });
+
+      const packagesToSave = await getKitPackagesToSave("/mock/src", "@scope/my-kit");
+
+      expect(packagesToSave).to.deep.equal(["firebase-functions@~7.1.3"]);
     });
   });
 
@@ -2789,6 +2939,34 @@ describe("functions/kits/install", () => {
   });
 
   describe("installKitOrInstance", () => {
+    // Function kits must declare 'firebase-functions' as a dependency or peer dependency.
+    // Provide a mock package-lock.json for the package kits installed in this suite
+    // so getKitPackagesToSave can resolve valid kit SDK versions during installation.
+    beforeEach(() => {
+      mockFs({
+        "/mock/project/function-kits/firestore-bigquery-export/source/package-lock.json": {
+          packages: {
+            "node_modules/@firebase-function-kits/firestore-bigquery-export": {
+              peerDependencies: {
+                "firebase-functions": "^7.0.0",
+              },
+            },
+            "node_modules/firebase-functions": { version: "7.3.2" },
+          },
+        },
+        "/mock/project/function-kits/custom-kit/source/package-lock.json": {
+          packages: {
+            "node_modules/@firebase-function-kits/firestore-bigquery-export": {
+              peerDependencies: {
+                "firebase-functions": "^7.0.0",
+              },
+            },
+            "node_modules/firebase-functions": { version: "7.3.2" },
+          },
+        },
+      });
+    });
+
     it("should throw an error if neither package nor directory is provided", async () => {
       const mockConfig = {
         projectDir: "/mock/project",
@@ -2909,7 +3087,7 @@ describe("functions/kits/install", () => {
       );
       expect(wrapSpawnStub.secondCall).to.have.been.calledWith(
         "npm",
-        ["install", "firebase-functions@latest", "--save-prefix=^"],
+        ["install", "firebase-functions@^7.3.2", "--save-prefix=^"],
         "/mock/project/function-kits/firestore-bigquery-export/source",
       );
       expect(wrapSpawnStub.thirdCall).to.have.been.calledWith(

--- a/src/functions/kits/install.spec.ts
+++ b/src/functions/kits/install.spec.ts
@@ -1515,7 +1515,7 @@ describe("functions/kits/install", () => {
       );
       expect(wrapSpawnStub.secondCall).to.have.been.calledWith(
         "npm",
-        ["install", "firebase-functions@latest", "--save-prefix=^"],
+        ["install", "firebase-functions@latest", "--save-prefix=^", "--ignore-scripts"],
         "/abs/path",
       );
       expect(wrapSpawnStub.thirdCall).to.have.been.calledWith("npm", ["run", "build"], "/abs/path");
@@ -1531,14 +1531,22 @@ describe("functions/kits/install", () => {
     });
 
     it("should throw FirebaseError if saving SDK dependencies fails", async () => {
+      const origError = new Error("ERESOLVE peer dependency conflict");
       wrapSpawnStub
         .withArgs("npm", ["install", "firebase-functions@latest", "--save-prefix=^"], "/abs/path")
-        .rejects(new Error("ERESOLVE peer dependency conflict"));
+        .rejects(origError);
 
-      await expect(buildAndInstallKit("/abs/path", "my-kit", false)).to.be.rejectedWith(
-        FirebaseError,
+      let err: unknown;
+      try {
+        await buildAndInstallKit("/abs/path", "my-kit", false);
+      } catch (e: unknown) {
+        err = e;
+      }
+      expect(err).to.be.an.instanceOf(FirebaseError);
+      expect((err as FirebaseError).message).to.match(
         /Failed to install required SDK dependencies/,
       );
+      expect((err as FirebaseError).original).to.equal(origError);
     });
 
     it("should throw FirebaseError if typescript build fails", async () => {

--- a/src/functions/kits/install.ts
+++ b/src/functions/kits/install.ts
@@ -717,11 +717,16 @@ export async function buildAndInstallKit(
       "functions",
       `Saving resolved SDK dependencies: ${clc.bold(packagesToSave.join(", "))}...`,
     );
+    const saveArgs = ["install", ...packagesToSave, "--save-prefix=^"];
+    if (isThirdParty) {
+      saveArgs.push("--ignore-scripts");
+    }
     try {
-      await wrapSpawn("npm", ["install", ...packagesToSave, "--save-prefix=^"], absSourcePath);
+      await wrapSpawn("npm", saveArgs, absSourcePath);
     } catch (err: unknown) {
       throw new FirebaseError(
         `Failed to install required SDK dependencies (${packagesToSave.join(", ")}): ${getErrMsg(err)}`,
+        { original: err instanceof Error ? err : undefined },
       );
     }
   }

--- a/src/functions/kits/install.ts
+++ b/src/functions/kits/install.ts
@@ -2,6 +2,7 @@ import * as crypto from "crypto";
 import * as path from "path";
 import * as clc from "colorette";
 import * as fs from "fs-extra";
+import * as semver from "semver";
 
 import { Config } from "../../config";
 import { FirebaseError, getErrMsg } from "../../error";
@@ -551,7 +552,9 @@ export async function writeKitPackageJson(
     try {
       pkgJson = JSON.parse(subbedTemplate) as typeof pkgJson;
     } catch (err: unknown) {
-      throw new FirebaseError("Failed to parse package-kit.json template: " + getErrMsg(err));
+      throw new FirebaseError("Failed to parse package-kit.json template: " + getErrMsg(err), {
+        original: err instanceof Error ? err : undefined,
+      });
     }
   }
 
@@ -611,6 +614,49 @@ export async function scaffoldKitFiles(
   return { sourcePath, configDirPath, absSourcePath, absConfigDirPath };
 }
 
+interface PackageLockEntry {
+  version?: string;
+  dependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+}
+
+interface PackageLock {
+  packages?: Record<string, PackageLockEntry>;
+}
+
+interface KitManifest {
+  dependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+}
+
+/**
+ * Resolves the package specifier to save to the wrapper package.json.
+ *
+ * - Exact pin (e.g. "7.1.0", "=7.1.0", "v7.1.0"): Preserved as exact ("=X.Y.Z").
+ * - Tilde range (e.g. "~7.1.0"): Preserved as tilde ("~installedVer" or declared).
+ * - Caret / wider range (e.g. "^7.0.0", ">=7.0.0"): Anchored to caret ("^installedVer" or declared).
+ */
+export function resolveSdkSpecifierToSave(
+  packageName: string,
+  declaredVer: string,
+  installedVer?: string,
+): string {
+  const cleanVer = semver.clean(declaredVer);
+  if (cleanVer) {
+    return `${packageName}@=${installedVer || cleanVer}`;
+  }
+
+  if (declaredVer.trim().startsWith("~")) {
+    return installedVer ? `${packageName}@~${installedVer}` : `${packageName}@${declaredVer}`;
+  }
+
+  if (installedVer) {
+    return `${packageName}@^${installedVer}`;
+  }
+
+  return `${packageName}@${declaredVer}`;
+}
+
 /**
  * Inspects package-lock.json (or node_modules as fallback) to determine which SDK versions
  * should be explicitly saved to the wrapper package.json using npm install.
@@ -628,16 +674,7 @@ export async function getKitPackagesToSave(
 
   if (await fs.pathExists(lockfilePath)) {
     try {
-      const lockfile = (await fs.readJson(lockfilePath)) as {
-        packages?: Record<
-          string,
-          {
-            version?: string;
-            dependencies?: Record<string, string>;
-            peerDependencies?: Record<string, string>;
-          }
-        >;
-      };
+      const lockfile = (await fs.readJson(lockfilePath)) as PackageLock;
       const packages = lockfile.packages || {};
       const kitEntry = packages[`node_modules/${packageName}`] || {};
       peerDeps = kitEntry.peerDependencies || {};
@@ -653,10 +690,7 @@ export async function getKitPackagesToSave(
     const kitPkgJsonPath = path.join(absSourcePath, "node_modules", packageName, "package.json");
     if (await fs.pathExists(kitPkgJsonPath)) {
       try {
-        const kitPkgJson = (await fs.readJson(kitPkgJsonPath)) as {
-          peerDependencies?: Record<string, string>;
-          dependencies?: Record<string, string>;
-        };
+        const kitPkgJson = (await fs.readJson(kitPkgJsonPath)) as KitManifest;
         peerDeps = kitPkgJson.peerDependencies || {};
         directDeps = kitPkgJson.dependencies || {};
       } catch (err: unknown) {
@@ -665,27 +699,24 @@ export async function getKitPackagesToSave(
     }
   }
 
-  // 1. Resolve firebase-functions (always required by index-kit.ts)
+  // 1. Resolve firebase-functions (must be declared by a valid Function Kit)
   const declaredFunctionsVer = peerDeps["firebase-functions"] || directDeps["firebase-functions"];
-  let functionsSpecifier: string;
-  if (installedFunctionsVer) {
-    functionsSpecifier = `firebase-functions@^${installedFunctionsVer}`;
-  } else if (declaredFunctionsVer) {
-    functionsSpecifier = `firebase-functions@${declaredFunctionsVer}`;
-  } else {
-    functionsSpecifier = "firebase-functions@latest";
+  if (!declaredFunctionsVer) {
+    throw new FirebaseError(
+      `Package '${packageName}' is not a valid Function Kit: it must declare 'firebase-functions' as a dependency or peer dependency.`,
+    );
   }
 
-  const packagesToSave: string[] = [functionsSpecifier];
+  const packagesToSave: string[] = [
+    resolveSdkSpecifierToSave("firebase-functions", declaredFunctionsVer, installedFunctionsVer),
+  ];
 
   // 2. Resolve firebase-admin (strictly conditional: only if kit declared it)
   const declaredAdminVer = peerDeps["firebase-admin"] || directDeps["firebase-admin"];
   if (declaredAdminVer) {
-    if (installedAdminVer) {
-      packagesToSave.push(`firebase-admin@^${installedAdminVer}`);
-    } else {
-      packagesToSave.push(`firebase-admin@${declaredAdminVer}`);
-    }
+    packagesToSave.push(
+      resolveSdkSpecifierToSave("firebase-admin", declaredAdminVer, installedAdminVer),
+    );
   }
 
   return packagesToSave;
@@ -725,7 +756,8 @@ export async function buildAndInstallKit(
       await wrapSpawn("npm", saveArgs, absSourcePath);
     } catch (err: unknown) {
       throw new FirebaseError(
-        `Failed to install required SDK dependencies (${packagesToSave.join(", ")}): ${getErrMsg(err)}`,
+        `Failed to install required SDK dependencies (${packagesToSave.join(", ")}): ${getErrMsg(err)}. ` +
+          "Verify that the kit's dependencies are compatible with the resolved Firebase SDK versions.",
         { original: err instanceof Error ? err : undefined },
       );
     }

--- a/src/functions/kits/install.ts
+++ b/src/functions/kits/install.ts
@@ -546,14 +546,12 @@ export async function writeKitPackageJson(
     }
   } else {
     const latestNodeVersion = supported.latest("nodejs").replace("nodejs", "");
-    const packageNoLintingTemplate = readTemplateSync(
-      "init/functions/typescript/package.nolint.json",
-    );
-    const subbedTemplate = packageNoLintingTemplate.replace(/{{RUNTIME}}/g, latestNodeVersion);
+    const packageKitTemplate = readTemplateSync("init/functions/typescript/package-kit.json");
+    const subbedTemplate = packageKitTemplate.replace(/{{RUNTIME}}/g, latestNodeVersion);
     try {
       pkgJson = JSON.parse(subbedTemplate) as typeof pkgJson;
     } catch (err: unknown) {
-      throw new FirebaseError("Failed to parse package.nolint.json template: " + getErrMsg(err));
+      throw new FirebaseError("Failed to parse package-kit.json template: " + getErrMsg(err));
     }
   }
 
@@ -614,6 +612,86 @@ export async function scaffoldKitFiles(
 }
 
 /**
+ * Inspects package-lock.json (or node_modules as fallback) to determine which SDK versions
+ * should be explicitly saved to the wrapper package.json using npm install.
+ */
+export async function getKitPackagesToSave(
+  absSourcePath: string,
+  packageName: string,
+): Promise<string[]> {
+  const lockfilePath = path.join(absSourcePath, "package-lock.json");
+
+  let peerDeps: Record<string, string> = {};
+  let directDeps: Record<string, string> = {};
+  let installedFunctionsVer: string | undefined;
+  let installedAdminVer: string | undefined;
+
+  if (await fs.pathExists(lockfilePath)) {
+    try {
+      const lockfile = (await fs.readJson(lockfilePath)) as {
+        packages?: Record<
+          string,
+          {
+            version?: string;
+            dependencies?: Record<string, string>;
+            peerDependencies?: Record<string, string>;
+          }
+        >;
+      };
+      const packages = lockfile.packages || {};
+      const kitEntry = packages[`node_modules/${packageName}`] || {};
+      peerDeps = kitEntry.peerDependencies || {};
+      directDeps = kitEntry.dependencies || {};
+      installedFunctionsVer = packages["node_modules/firebase-functions"]?.version;
+      installedAdminVer = packages["node_modules/firebase-admin"]?.version;
+    } catch (err: unknown) {
+      logger.debug(`Failed to read package-lock.json: ${getErrMsg(err)}`);
+    }
+  }
+
+  if (Object.keys(peerDeps).length === 0 && Object.keys(directDeps).length === 0) {
+    const kitPkgJsonPath = path.join(absSourcePath, "node_modules", packageName, "package.json");
+    if (await fs.pathExists(kitPkgJsonPath)) {
+      try {
+        const kitPkgJson = (await fs.readJson(kitPkgJsonPath)) as {
+          peerDependencies?: Record<string, string>;
+          dependencies?: Record<string, string>;
+        };
+        peerDeps = kitPkgJson.peerDependencies || {};
+        directDeps = kitPkgJson.dependencies || {};
+      } catch (err: unknown) {
+        logger.debug(`Failed to read kit package.json: ${getErrMsg(err)}`);
+      }
+    }
+  }
+
+  // 1. Resolve firebase-functions (always required by index-kit.ts)
+  const declaredFunctionsVer = peerDeps["firebase-functions"] || directDeps["firebase-functions"];
+  let functionsSpecifier: string;
+  if (installedFunctionsVer) {
+    functionsSpecifier = `firebase-functions@^${installedFunctionsVer}`;
+  } else if (declaredFunctionsVer) {
+    functionsSpecifier = `firebase-functions@${declaredFunctionsVer}`;
+  } else {
+    functionsSpecifier = "firebase-functions@latest";
+  }
+
+  const packagesToSave: string[] = [functionsSpecifier];
+
+  // 2. Resolve firebase-admin (strictly conditional: only if kit declared it)
+  const declaredAdminVer = peerDeps["firebase-admin"] || directDeps["firebase-admin"];
+  if (declaredAdminVer) {
+    if (installedAdminVer) {
+      packagesToSave.push(`firebase-admin@^${installedAdminVer}`);
+    } else {
+      packagesToSave.push(`firebase-admin@${declaredAdminVer}`);
+    }
+  }
+
+  return packagesToSave;
+}
+
+/**
  * Installs dependencies and compiles TypeScript source for the kit.
  */
 export async function buildAndInstallKit(
@@ -621,6 +699,7 @@ export async function buildAndInstallKit(
   rawPkgName: string,
   isThirdParty: boolean,
 ): Promise<void> {
+  const { packageName } = parseNpmPackageSpecifier(rawPkgName);
   const installArgs = ["install", rawPkgName, "--save-prefix=^"];
   if (isThirdParty) {
     installArgs.push("--ignore-scripts");
@@ -630,6 +709,21 @@ export async function buildAndInstallKit(
     await wrapSpawn("npm", installArgs, absSourcePath);
   } catch (err: unknown) {
     throw new FirebaseError(`NPM install failed: ${getErrMsg(err)}`);
+  }
+
+  const packagesToSave = await getKitPackagesToSave(absSourcePath, packageName);
+  if (packagesToSave.length > 0) {
+    logLabeledBullet(
+      "functions",
+      `Saving resolved SDK dependencies: ${clc.bold(packagesToSave.join(", "))}...`,
+    );
+    try {
+      await wrapSpawn("npm", ["install", ...packagesToSave, "--save-prefix=^"], absSourcePath);
+    } catch (err: unknown) {
+      throw new FirebaseError(
+        `Failed to install required SDK dependencies (${packagesToSave.join(", ")}): ${getErrMsg(err)}`,
+      );
+    }
   }
 
   logLabeledBullet("functions", "Building TypeScript source...");

--- a/templates/init/functions/typescript/package-kit.json
+++ b/templates/init/functions/typescript/package-kit.json
@@ -1,0 +1,21 @@
+{
+  "name": "functions",
+  "scripts": {
+    "build": "tsc",
+    "build:watch": "tsc --watch",
+    "serve": "npm run build && firebase emulators:start --only functions",
+    "shell": "npm run build && firebase functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
+  },
+  "engines": {
+    "node": "{{RUNTIME}}"
+  },
+  "main": "lib/index.js",
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^6.0.0"
+  },
+  "private": true
+}


### PR DESCRIPTION
### Description

Updates Functions Kits installation to dynamically resolve and save SDK dependencies based on what the kit declares and npm installs, eliminating hardcoded pinned versions.

Key changes:
- **Dedicated Kit Template**: Added package-kit.json template starting with empty dependencies: {} and omitting firebase-functions-test.
- **Dynamic Dependency Resolution**: After the initial kit install, inspects package-lock.json (falling back to the kit manifest) to determine SDK versions. Always saves firebase-functions, and only saves firebase-admin if explicitly declared by the kit.
- **NPM-Managed Saving**: Uses npm install to update package.json and package-lock.json, failing fast if dependency resolution fails.

### Scenarios Tested

- **Unit tests**: Added and updated tests in install.spec.ts covering SDK version resolution from lockfile and fallback manifests, conditional omission of firebase-admin, template scaffolding, and install failure handling.
- npm test
- npm run build
- Manually testing with firebase functions:kits:install

### Sample Commands

```bash
firebase functions:kits:install @firebase-function-kits/firestore-bigquery-export
```