### PR TITLE
fix(extensions): strip ANSI codes in listExtensions table test for co…

### DIFF
--- a/src/extensions/listExtensions.spec.ts
+++ b/src/extensions/listExtensions.spec.ts
@@ -64,15 +64,8 @@ const MOCK_INSTANCES = [
   },
 ];
 
-/**
- * In interactive TTY environments or when colors are enabled in Mocha, cli-table3
- * styles border characters with ANSI color escape codes (e.g. \u001b[90m), which prevents
- * raw border character matching like line.trim().startsWith("│").
- *
- * This helper dynamically locates the table logger call and strips VT/ANSI control
- * characters so that row and column parsing works consistently across all terminal
- * and test runner configurations.
- */
+// Locates the table log call and strips ANSI styling so row parsing
+// works consistently in both TTY and non-TTY test runners.
 function findTableOutput(stub: sinon.SinonStub): string {
   const call = stub.args.find(
     (args) => typeof args[0] === "string" && args[0].includes("Extension"),

--- a/src/extensions/listExtensions.spec.ts
+++ b/src/extensions/listExtensions.spec.ts
@@ -1,3 +1,4 @@
+import { stripVTControlCharacters } from "util";
 import { expect } from "chai";
 import * as sinon from "sinon";
 
@@ -63,6 +64,14 @@ const MOCK_INSTANCES = [
   },
 ];
 
+function findTableOutput(stub: sinon.SinonStub): string {
+  const call = stub.args.find(
+    (args) => typeof args[0] === "string" && args[0].includes("Extension"),
+  );
+  expect(call).to.not.be.undefined;
+  return typeof call?.[0] === "string" ? stripVTControlCharacters(call[0]) : "";
+}
+
 const PROJECT_ID = "my-test-proj";
 
 describe("listExtensions", () => {
@@ -119,7 +128,7 @@ describe("listExtensions", () => {
       await listExtensions(PROJECT_ID);
 
       expect(loggerInfoStub.called).to.be.true;
-      const tableString = String(loggerInfoStub.secondCall.args[0]);
+      const tableString = findTableOutput(loggerInfoStub);
 
       const rows = tableString
         .split("\n")
@@ -195,7 +204,7 @@ describe("listExtensions", () => {
       await listExtensions(PROJECT_ID);
 
       expect(loggerInfoStub.called).to.be.true;
-      const tableString = String(loggerInfoStub.secondCall.args[0]);
+      const tableString = findTableOutput(loggerInfoStub);
 
       // Extract each row between the '│' boundaries
       const rows = tableString

--- a/src/extensions/listExtensions.spec.ts
+++ b/src/extensions/listExtensions.spec.ts
@@ -64,6 +64,15 @@ const MOCK_INSTANCES = [
   },
 ];
 
+/**
+ * In interactive TTY environments or when colors are enabled in Mocha, cli-table3
+ * styles border characters with ANSI color escape codes (e.g. \u001b[90m), which prevents
+ * raw border character matching like line.trim().startsWith("│").
+ *
+ * This helper dynamically locates the table logger call and strips VT/ANSI control
+ * characters so that row and column parsing works consistently across all terminal
+ * and test runner configurations.
+ */
 function findTableOutput(stub: sinon.SinonStub): string {
   const call = stub.args.find(
     (args) => typeof args[0] === "string" && args[0].includes("Extension"),


### PR DESCRIPTION
### Description

Hardens unit test assertions in `src/extensions/listExtensions.spec.ts` to ensure consistent execution across different terminal and test runner environments:

- **ANSI escape code stripping:** In interactive TTY terminals or environments with colors enabled, `cli-table3` applies default border styling (`\u001b[90m`), causing row matching on raw border characters (`startsWith("│")`) to fail. Uses Node's built-in `stripVTControlCharacters` so table structure assertions succeed regardless of color settings.
- **Dynamic table call lookup:** Replaces the fixed `.secondCall` index assumption on the logger stub with dynamic call matching, making the test resilient to logging call order.

Follow-up to #10986.

### Scenarios Tested

- Ran `npx mocha src/extensions/listExtensions.spec.ts` locally in an interactive terminal (TTY).
- Verified tests pass with both `FORCE_COLOR=1` and `FORCE_COLOR=0`.
- Ran `npm run lint:changed-files` (0 errors, 0 warnings).
