### PR TITLE
feat: add support for FIREBASE_DEBUG_PATH environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for the `FIREBASE_DEBUG_PATH` environment variable to customize the debug log output location.
 - Add `humanReadableDescription` field to MCP tools and use it in `--generate-tool-list` output.
 - Fixed an issue where the Functions emulator replaced an IPC failure with an unrelated `TypeError` about stream chunk types, hiding why the runtime became unreachable (#10876).
 - [Added] Add -f, --force option to `firebase ext:migrate`.

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -110,7 +110,10 @@ export function cli(pkg: any) {
         if (code === 1 && cmd) {
           help = "Having trouble? Try " + clc.bold("firebase [command] --help");
         } else {
-          help = "Having trouble? Try again or contact support with contents of firebase-debug.log";
+          const logFileDisplay = process.env.FIREBASE_DEBUG_PATH
+            ? logFilename
+            : "firebase-debug.log";
+          help = `Having trouble? Try again or contact support with contents of ${logFileDisplay}`;
         }
 
         if (cmd) {

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -110,10 +110,7 @@ export function cli(pkg: any) {
         if (code === 1 && cmd) {
           help = "Having trouble? Try " + clc.bold("firebase [command] --help");
         } else {
-          const logFileDisplay = process.env.FIREBASE_DEBUG_PATH?.trim()
-            ? logFilename
-            : "firebase-debug.log";
-          help = `Having trouble? Try again or contact support with contents of ${logFileDisplay}`;
+          help = `Having trouble? Try again or contact support with contents of ${logFilename}`;
         }
 
         if (cmd) {

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -110,7 +110,7 @@ export function cli(pkg: any) {
         if (code === 1 && cmd) {
           help = "Having trouble? Try " + clc.bold("firebase [command] --help");
         } else {
-          const logFileDisplay = process.env.FIREBASE_DEBUG_PATH
+          const logFileDisplay = process.env.FIREBASE_DEBUG_PATH?.trim()
             ? logFilename
             : "firebase-debug.log";
           help = `Having trouble? Try again or contact support with contents of ${logFileDisplay}`;

--- a/src/bin/mcp.ts
+++ b/src/bin/mcp.ts
@@ -95,7 +95,7 @@ export async function mcp(): Promise<void> {
   }
 
   setFirebaseMcp(true);
-  if (process.env.FIREBASE_DEBUG_PATH) {
+  if (process.env.FIREBASE_DEBUG_PATH?.trim()) {
     useFileLogger();
   } else {
     // Write debug logs to ~/.cache/firebase to avoid polluting the user's project directory.

--- a/src/bin/mcp.ts
+++ b/src/bin/mcp.ts
@@ -95,10 +95,14 @@ export async function mcp(): Promise<void> {
   }
 
   setFirebaseMcp(true);
-  // Write debug logs to ~/.cache/firebase to avoid polluting the user's project directory.
-  const mcpLogDir = join(homedir(), ".cache", "firebase");
-  await mkdir(mcpLogDir, { recursive: true });
-  useFileLogger(join(mcpLogDir, "firebase-debug.log"));
+  if (process.env.FIREBASE_DEBUG_PATH) {
+    useFileLogger();
+  } else {
+    // Write debug logs to ~/.cache/firebase to avoid polluting the user's project directory.
+    const mcpLogDir = join(homedir(), ".cache", "firebase");
+    await mkdir(mcpLogDir, { recursive: true });
+    useFileLogger(join(mcpLogDir, "firebase-debug.log"));
+  }
   const activeFeatures = (values.only || "")
     .split(",")
     .map((f) => f.trim())

--- a/src/logger.spec.ts
+++ b/src/logger.spec.ts
@@ -1,0 +1,285 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import * as Transport from "winston-transport";
+
+import { logger, findAvailableLogFile, resolveLogTarget, useFileLogger } from "./logger";
+
+interface FileTransport extends Transport {
+  filename?: string;
+  close?: () => void;
+}
+
+interface LoggerWithTransports {
+  transports: FileTransport[];
+}
+
+function getLoggerTransports(logObj: unknown): FileTransport[] {
+  if (typeof logObj === "object" && logObj !== null && "transports" in logObj) {
+    return (logObj as LoggerWithTransports).transports;
+  }
+  return [];
+}
+
+describe("logger", () => {
+  const originalEnv = process.env.FIREBASE_DEBUG_PATH;
+  let testTmpDir: string;
+
+  beforeEach(() => {
+    delete process.env.FIREBASE_DEBUG_PATH;
+    testTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "firebase-debug-test-"));
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.FIREBASE_DEBUG_PATH = originalEnv;
+    } else {
+      delete process.env.FIREBASE_DEBUG_PATH;
+    }
+    sinon.restore();
+    if (fs.existsSync(testTmpDir)) {
+      fs.rmSync(testTmpDir, { recursive: true, force: true });
+    }
+  });
+
+  describe("resolveLogTarget", () => {
+    it("should return default when no path or env is set", () => {
+      const target = resolveLogTarget();
+      expect(target.baseDir).to.equal(process.cwd());
+      expect(target.baseName).to.equal("firebase-debug");
+      expect(target.ext).to.equal(".log");
+    });
+
+    it("should ignore empty or whitespace-only debug path", () => {
+      expect(resolveLogTarget("")).to.deep.equal({
+        baseDir: process.cwd(),
+        baseName: "firebase-debug",
+        ext: ".log",
+      });
+      expect(resolveLogTarget("   ")).to.deep.equal({
+        baseDir: process.cwd(),
+        baseName: "firebase-debug",
+        ext: ".log",
+      });
+
+      process.env.FIREBASE_DEBUG_PATH = "   ";
+      expect(resolveLogTarget()).to.deep.equal({
+        baseDir: process.cwd(),
+        baseName: "firebase-debug",
+        ext: ".log",
+      });
+    });
+
+    it("should use FIREBASE_DEBUG_PATH env var when customPath is not provided", () => {
+      process.env.FIREBASE_DEBUG_PATH = testTmpDir;
+      const target = resolveLogTarget();
+      expect(target.baseDir).to.equal(testTmpDir);
+      expect(target.baseName).to.equal("firebase-debug");
+      expect(target.ext).to.equal(".log");
+    });
+
+    it("should prioritize customPath over FIREBASE_DEBUG_PATH env var", () => {
+      process.env.FIREBASE_DEBUG_PATH = "/env/path";
+      const target = resolveLogTarget(testTmpDir);
+      expect(target.baseDir).to.equal(testTmpDir);
+    });
+
+    it("should handle existing directory", () => {
+      const target = resolveLogTarget(testTmpDir);
+      expect(target.baseDir).to.equal(testTmpDir);
+      expect(target.baseName).to.equal("firebase-debug");
+      expect(target.ext).to.equal(".log");
+    });
+
+    it("should handle existing file", () => {
+      const existingFile = path.join(testTmpDir, "my-log.txt");
+      fs.writeFileSync(existingFile, "hello");
+
+      const target = resolveLogTarget(existingFile);
+      expect(target.baseDir).to.equal(testTmpDir);
+      expect(target.baseName).to.equal("my-log");
+      expect(target.ext).to.equal(".txt");
+    });
+
+    it("should handle non-existent directory ending in separator", () => {
+      const targetDir = path.join(testTmpDir, "new-dir") + path.sep;
+      const target = resolveLogTarget(targetDir);
+      expect(target.baseDir).to.equal(path.join(testTmpDir, "new-dir"));
+      expect(target.baseName).to.equal("firebase-debug");
+      expect(target.ext).to.equal(".log");
+    });
+
+    it("should handle non-existent directory without extension", () => {
+      const targetDir = path.join(testTmpDir, "logs");
+      const target = resolveLogTarget(targetDir);
+      expect(target.baseDir).to.equal(targetDir);
+      expect(target.baseName).to.equal("firebase-debug");
+      expect(target.ext).to.equal(".log");
+    });
+
+    it("should handle non-existent file path with extension", () => {
+      const filePath = path.join(testTmpDir, "sub", "custom-output.log");
+      const target = resolveLogTarget(filePath);
+      expect(target.baseDir).to.equal(path.join(testTmpDir, "sub"));
+      expect(target.baseName).to.equal("custom-output");
+      expect(target.ext).to.equal(".log");
+    });
+
+    it("should resolve relative paths against process.cwd()", () => {
+      const target = resolveLogTarget("my-debug.log");
+      expect(target.baseDir).to.equal(process.cwd());
+      expect(target.baseName).to.equal("my-debug");
+      expect(target.ext).to.equal(".log");
+    });
+
+    it("should expand ~ to home directory", () => {
+      const target = resolveLogTarget("~/firebase-debug.log");
+      expect(target.baseDir).to.equal(os.homedir());
+      expect(target.baseName).to.equal("firebase-debug");
+      expect(target.ext).to.equal(".log");
+    });
+
+    it("should expand ~ alone to home directory", () => {
+      const target = resolveLogTarget("~");
+      expect(target.baseDir).to.equal(os.homedir());
+      expect(target.baseName).to.equal("firebase-debug");
+      expect(target.ext).to.equal(".log");
+    });
+  });
+
+  describe("findAvailableLogFile", () => {
+    it("should return firebase-debug.log inside specified directory if available", () => {
+      const logFile = findAvailableLogFile(testTmpDir);
+      expect(logFile).to.equal(path.join(testTmpDir, "firebase-debug.log"));
+    });
+
+    it("should create directory if it does not exist", () => {
+      const newDir = path.join(testTmpDir, "nested", "log-dir");
+      const logFile = findAvailableLogFile(newDir);
+      expect(fs.existsSync(newDir)).to.be.true;
+      expect(logFile).to.equal(path.join(newDir, "firebase-debug.log"));
+    });
+
+    it("should return the custom file name when specified", () => {
+      const customFile = path.join(testTmpDir, "app-debug.log");
+      const logFile = findAvailableLogFile(customFile);
+      expect(logFile).to.equal(customFile);
+    });
+
+    it("should fall back to numbered candidates when primary file cannot be opened", () => {
+      const originalOpenSync = fs.openSync;
+      const primaryFile = path.join(testTmpDir, "firebase-debug.log");
+      // Create primary file
+      fs.writeFileSync(primaryFile, "existing");
+
+      sinon.stub(fs, "openSync").callsFake(((filePath: fs.PathLike, flags: fs.OpenMode) => {
+        if (filePath === primaryFile) {
+          const err: NodeJS.ErrnoException = new Error("Permission denied");
+          err.code = "EPERM";
+          throw err;
+        }
+        return originalOpenSync(filePath, flags);
+      }) as typeof fs.openSync);
+
+      const logFile = findAvailableLogFile(testTmpDir);
+      expect(logFile).to.equal(path.join(testTmpDir, "firebase-debug.1.log"));
+    });
+
+    it("should throw an error if all candidate files fail permissions", () => {
+      sinon.stub(fs, "openSync").callsFake(() => {
+        const err: NodeJS.ErrnoException = new Error("Permission denied");
+        err.code = "EPERM";
+        throw err;
+      });
+
+      expect(() => findAvailableLogFile(testTmpDir)).to.throw(
+        "Unable to obtain permissions for firebase-debug.log",
+      );
+    });
+
+    it("should throw an error if parent directory is not writable", () => {
+      sinon.stub(fs, "accessSync").callsFake(() => {
+        const err: NodeJS.ErrnoException = new Error("Permission denied");
+        err.code = "EACCES";
+        throw err;
+      });
+
+      expect(() => findAvailableLogFile(testTmpDir)).to.throw(
+        "Unable to obtain permissions for firebase-debug.log",
+      );
+    });
+
+    it("should respect FIREBASE_DEBUG_PATH environment variable", () => {
+      process.env.FIREBASE_DEBUG_PATH = path.join(testTmpDir, "env-debug.log");
+      const logFile = findAvailableLogFile();
+      expect(logFile).to.equal(path.join(testTmpDir, "env-debug.log"));
+    });
+
+    it("should respect FIREBASE_DEBUG_PATH when set to an existing directory", () => {
+      process.env.FIREBASE_DEBUG_PATH = testTmpDir;
+      const logFile = findAvailableLogFile();
+      expect(logFile).to.equal(path.join(testTmpDir, "firebase-debug.log"));
+    });
+
+    it("should create directory from FIREBASE_DEBUG_PATH if it does not exist", () => {
+      const nestedDir = path.join(testTmpDir, "sub", "logs");
+      process.env.FIREBASE_DEBUG_PATH = nestedDir;
+      const logFile = findAvailableLogFile();
+      expect(fs.existsSync(nestedDir)).to.be.true;
+      expect(logFile).to.equal(path.join(nestedDir, "firebase-debug.log"));
+    });
+
+    it("should create parent directory from FIREBASE_DEBUG_PATH when pointing to a file", () => {
+      const targetFile = path.join(testTmpDir, "nested", "custom.log");
+      process.env.FIREBASE_DEBUG_PATH = targetFile;
+      const logFile = findAvailableLogFile();
+      expect(fs.existsSync(path.dirname(targetFile))).to.be.true;
+      expect(logFile).to.equal(targetFile);
+    });
+
+    it("should trim FIREBASE_DEBUG_PATH", () => {
+      process.env.FIREBASE_DEBUG_PATH = `  ${path.join(testTmpDir, "trimmed.log")}  `;
+      const logFile = findAvailableLogFile();
+      expect(logFile).to.equal(path.join(testTmpDir, "trimmed.log"));
+    });
+  });
+
+  describe("useFileLogger", () => {
+    it("should use FIREBASE_DEBUG_PATH if set", () => {
+      const targetFile = path.join(testTmpDir, "use-file-logger.log");
+      process.env.FIREBASE_DEBUG_PATH = targetFile;
+
+      const logFile = useFileLogger();
+      expect(logFile).to.equal(targetFile);
+
+      // Clean up winston transport added by useFileLogger
+      const transports = getLoggerTransports(logger);
+      const fileTransport = transports.find((t) => t.filename === targetFile);
+      if (fileTransport) {
+        logger.remove(fileTransport);
+        if (fileTransport.close) {
+          fileTransport.close();
+        }
+      }
+    });
+
+    it("should allow explicit logFile override", () => {
+      const explicitFile = path.join(testTmpDir, "explicit.log");
+      const logFile = useFileLogger(explicitFile);
+      expect(logFile).to.equal(explicitFile);
+
+      // Clean up winston transport
+      const transports = getLoggerTransports(logger);
+      const fileTransport = transports.find((t) => t.filename === explicitFile);
+      if (fileTransport) {
+        logger.remove(fileTransport);
+        if (fileTransport.close) {
+          fileTransport.close();
+        }
+      }
+    });
+  });
+});

--- a/src/logger.spec.ts
+++ b/src/logger.spec.ts
@@ -104,6 +104,17 @@ describe("logger", () => {
       expect(target.ext).to.equal(".txt");
     });
 
+    it("should handle error thrown by fs.statSync gracefully", () => {
+      const existingFile = path.join(testTmpDir, "stat-error.log");
+      fs.writeFileSync(existingFile, "hello");
+      sinon.stub(fs, "statSync").throws(new Error("EPERM"));
+
+      const target = resolveLogTarget(existingFile);
+      expect(target.baseDir).to.equal(testTmpDir);
+      expect(target.baseName).to.equal("stat-error");
+      expect(target.ext).to.equal(".log");
+    });
+
     it("should handle non-existent directory ending in separator", () => {
       const targetDir = path.join(testTmpDir, "new-dir") + path.sep;
       const target = resolveLogTarget(targetDir);
@@ -193,6 +204,16 @@ describe("logger", () => {
         const err: NodeJS.ErrnoException = new Error("Permission denied");
         err.code = "EPERM";
         throw err;
+      });
+
+      expect(() => findAvailableLogFile(testTmpDir)).to.throw(
+        "Unable to obtain permissions for firebase-debug.log",
+      );
+    });
+
+    it("should handle error without code property thrown by fs.openSync", () => {
+      sinon.stub(fs, "openSync").callsFake(() => {
+        throw new Error("unexpected error without code");
       });
 
       expect(() => findAvailableLogFile(testTmpDir)).to.throw(

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,6 +2,7 @@ import * as winston from "winston";
 import * as Transport from "winston-transport";
 import { EventEmitter } from "events";
 import * as path from "path";
+import * as os from "os";
 import * as fs from "fs";
 import { SPLAT } from "triple-beam";
 import { stripVTControlCharacters } from "util";
@@ -123,28 +124,111 @@ function maybeUseVSCodeLogger(logger: winston.Logger): winston.Logger {
   return logger;
 }
 
-export function findAvailableLogFile(): string {
-  const candidates = ["firebase-debug.log"];
+export interface LogTarget {
+  baseDir: string;
+  baseName: string;
+  ext: string;
+}
+
+/**
+ * Resolves the directory, base filename, and extension for the debug log file.
+ */
+export function resolveLogTarget(customPath?: string): LogTarget {
+  const debugPath = customPath ?? process.env.FIREBASE_DEBUG_PATH;
+  if (!debugPath || !debugPath.trim()) {
+    return {
+      baseDir: process.cwd(),
+      baseName: "firebase-debug",
+      ext: ".log",
+    };
+  }
+
+  let trimmed = debugPath.trim();
+  if (trimmed === "~" || trimmed.startsWith("~/") || trimmed.startsWith("~\\")) {
+    trimmed = path.join(os.homedir(), trimmed.slice(1));
+  }
+
+  const resolvedPath = path.resolve(process.cwd(), trimmed);
+
+  if (fs.existsSync(resolvedPath)) {
+    if (fs.statSync(resolvedPath).isDirectory()) {
+      return {
+        baseDir: resolvedPath,
+        baseName: "firebase-debug",
+        ext: ".log",
+      };
+    }
+    const ext = path.extname(resolvedPath);
+    return {
+      baseDir: path.dirname(resolvedPath),
+      baseName: path.basename(resolvedPath, ext),
+      ext,
+    };
+  }
+
+  if (trimmed.endsWith(path.sep) || trimmed.endsWith("/") || trimmed.endsWith("\\")) {
+    return {
+      baseDir: resolvedPath,
+      baseName: "firebase-debug",
+      ext: ".log",
+    };
+  }
+
+  const ext = path.extname(resolvedPath);
+  if (ext) {
+    return {
+      baseDir: path.dirname(resolvedPath),
+      baseName: path.basename(resolvedPath, ext),
+      ext,
+    };
+  }
+
+  return {
+    baseDir: resolvedPath,
+    baseName: "firebase-debug",
+    ext: ".log",
+  };
+}
+
+/**
+ * Finds an available debug log file path, checking permissions and creating directories as needed.
+ */
+export function findAvailableLogFile(customPath?: string): string {
+  const { baseDir, baseName, ext } = resolveLogTarget(customPath);
+
+  if (!fs.existsSync(baseDir)) {
+    try {
+      fs.mkdirSync(baseDir, { recursive: true });
+    } catch {
+      // Any error creating the directory means we won't be able to log here.
+    }
+  }
+
+  const candidates = [`${baseName}${ext}`];
   for (let i = 1; i < 10; i++) {
-    candidates.push(`firebase-debug.${i}.log`);
+    candidates.push(`${baseName}.${i}${ext}`);
   }
 
   for (const c of candidates) {
-    const logFilename = path.join(process.cwd(), c);
+    const logFilename = path.join(baseDir, c);
     try {
       const fd = fs.openSync(logFilename, "r+");
       fs.closeSync(fd);
       return logFilename;
-    } catch (e: any) {
-      if (e.code === "ENOENT") {
-        // File does not exist, which is fine
-        return logFilename;
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        try {
+          fs.accessSync(baseDir, fs.constants.W_OK);
+          return logFilename;
+        } catch {
+          // Parent directory is not writable, skip candidate.
+        }
       }
       // Any other error (EPERM, etc) means we won't be able to log to
       // this file so we skip it.
     }
   }
-  throw new Error("Unable to obtain permissions for firebase-debug.log");
+  throw new Error(`Unable to obtain permissions for ${baseName}${ext}`);
 }
 
 export function tryStringify(value: any) {
@@ -183,7 +267,7 @@ export const logger: Logger = maybeUseVSCodeLogger(
  * Sets up logging to the firebase-debug.log file.
  */
 export function useFileLogger(logFile?: string): string {
-  const logFileName = logFile ?? findAvailableLogFile();
+  const logFileName = logFile ? findAvailableLogFile(logFile) : findAvailableLogFile();
   logger.add(
     new winston.transports.File({
       level: "debug",

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -151,7 +151,13 @@ export function resolveLogTarget(customPath?: string): LogTarget {
   const resolvedPath = path.resolve(process.cwd(), trimmed);
 
   if (fs.existsSync(resolvedPath)) {
-    if (fs.statSync(resolvedPath).isDirectory()) {
+    let isDir = false;
+    try {
+      isDir = fs.statSync(resolvedPath).isDirectory();
+    } catch {
+      // If stat fails, assume it's not a directory
+    }
+    if (isDir) {
       return {
         baseDir: resolvedPath,
         baseName: "firebase-debug",
@@ -216,7 +222,12 @@ export function findAvailableLogFile(customPath?: string): string {
       fs.closeSync(fd);
       return logFilename;
     } catch (err: unknown) {
-      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      if (
+        typeof err === "object" &&
+        err !== null &&
+        "code" in err &&
+        (err as { code?: string }).code === "ENOENT"
+      ) {
         try {
           fs.accessSync(baseDir, fs.constants.W_OK);
           return logFilename;
@@ -267,7 +278,7 @@ export const logger: Logger = maybeUseVSCodeLogger(
  * Sets up logging to the firebase-debug.log file.
  */
 export function useFileLogger(logFile?: string): string {
-  const logFileName = logFile ? findAvailableLogFile(logFile) : findAvailableLogFile();
+  const logFileName = findAvailableLogFile(logFile);
   logger.add(
     new winston.transports.File({
       level: "debug",


### PR DESCRIPTION
### Description
Adds support for the `FIREBASE_DEBUG_PATH` environment variable, allowing users to customize the output location and filename of `firebase-debug.log`. This is especially useful in environments where the current working directory is read-only, in CI/CD pipelines, or when users want to centralize Firebase CLI logs.

Key changes:
- Added `resolveLogTarget()` in `src/logger.ts` to resolve target directories, filenames, extension, and expand `~` home directory paths.
- Updated `findAvailableLogFile()` to automatically create missing parent directories and rotate candidate filenames on permission/lock errors.
- Updated CLI exit error handling in `src/bin/cli.ts` to reference the custom log path if set.
- Updated MCP server initialization in `src/bin/mcp.ts` to respect `FIREBASE_DEBUG_PATH` when configured.
- Added comprehensive unit tests in `src/logger.spec.ts`.
- Added an entry to `CHANGELOG.md`.

### Scenarios Tested
- Default behavior with no `FIREBASE_DEBUG_PATH` set (outputs to `./firebase-debug.log`).
- `FIREBASE_DEBUG_PATH` set to a custom file path (`/tmp/custom/my-debug.log`), verifying parent directory creation and file output.
- `FIREBASE_DEBUG_PATH` set to directory paths with and without trailing slash.
- `FIREBASE_DEBUG_PATH` using `~` home directory expansion.
- Candidate file rotation when the primary log file exists and is not writable.
- MCP server start with `FIREBASE_DEBUG_PATH`.
- Unit test suite (`npx mocha src/logger.spec.ts`) with all 25 tests passing.
- TypeScript compilation and ESLint checks.

### Sample Commands
- `FIREBASE_DEBUG_PATH=/tmp/firebase-debug.log firebase deploy --debug`
- `FIREBASE_DEBUG_PATH=~/logs/firebase/ firebase projects:list --debug`
- `FIREBASE_DEBUG_PATH=./custom-debug.log firebase emulators:start`
