### PR TITLE
Clean up multi-value slop

### DIFF
--- a/templates/init/functions/typescript/index-kit-migration.ts
+++ b/templates/init/functions/typescript/index-kit-migration.ts
@@ -51,10 +51,11 @@ setGlobalOptions({
           const [key, value] = curr.split(":");
           const trimmedKey = key?.trim();
           const trimmedValue = value?.trim();
-          if (trimmedKey && trimmedValue) {
-            acc = acc ?? {};
-            acc[trimmedKey] = trimmedValue;
+          if (!trimmedKey || !trimmedValue) {
+            return acc;
           }
+          acc = acc ?? {};
+          acc[trimmedKey] = trimmedValue;
           return acc;
         },
         undefined,

--- a/templates/init/functions/typescript/index-kit-migration.ts
+++ b/templates/init/functions/typescript/index-kit-migration.ts
@@ -48,11 +48,12 @@ setGlobalOptions({
   labels: process.env.EXT_MIGRATED_SYSTEM_LABELS
     ? process.env.EXT_MIGRATED_SYSTEM_LABELS.split(",").reduce<Record<string, string> | undefined>(
         (acc, curr) => {
-          const [key, ...values] = curr.split(":");
+          const [key, value] = curr.split(":");
           const trimmedKey = key?.trim();
-          if (trimmedKey && values.length > 0) {
+          const trimmedValue = value?.trim();
+          if (trimmedKey && trimmedValue) {
             acc = acc ?? {};
-            acc[trimmedKey] = values.join(":").trim();
+            acc[trimmedKey] = trimmedValue;
           }
           return acc;
         },


### PR DESCRIPTION
Simplify the code a bit by expecting one value per key. This was overlooked in the last PR.