### PR TITLE
Add requireConfig and requireAuth checks to kits commands

### DIFF
--- a/src/commands/functions-kits-install.spec.ts
+++ b/src/commands/functions-kits-install.spec.ts
@@ -7,6 +7,7 @@ import * as experiments from "../experiments";
 import { Config } from "../config";
 import { FirebaseError } from "../error";
 import { RC } from "../rc";
+import { requireAuth } from "../requireAuth";
 import { requireConfig } from "../requireConfig";
 
 describe("functions:kits:install", () => {
@@ -15,6 +16,7 @@ describe("functions:kits:install", () => {
   let installKitOrInstanceStub: sinon.SinonStub;
 
   beforeEach(() => {
+    command["befores"] = [];
     sinon.stub(command, "prepare").resolves();
     assertEnabledStub = sinon.stub(experiments, "assertEnabled");
     installKitOrInstanceStub = sinon.stub(kits, "installKitOrInstance").resolves({
@@ -29,58 +31,16 @@ describe("functions:kits:install", () => {
     sinon.restore();
   });
 
-  describe("command prerequisites", () => {
-    it("should throw an error and not start install if requireConfig is not met", async () => {
-      await expect(
-        command.runner()({
-          package: "@firebase-function-kits/firestore-bigquery-export",
-          cwd: "/mock/project",
-          nonInteractive: true,
-        }),
-      ).to.be.rejectedWith(FirebaseError, /could not locate firebase\.json/);
-
-      expect(installKitOrInstanceStub).not.to.have.been.called;
-    });
-
-    it("should throw an error and not start install if requireAuth is not met", async () => {
-      const mockConfig = {
-        projectDir: "/mock/project",
-        src: {
-          functions: [],
-        },
-        path: (p: string) => `/mock/project/${p}`,
-      } as unknown as Config;
-
-      const authError = new FirebaseError(
-        "Command requires authentication, please run firebase login",
-      );
-      const requireAuthStub = sinon.stub().rejects(authError);
-      command["befores"] = [
+  describe("command configuration", () => {
+    it("should have requireConfig and requireAuth as before hooks", () => {
+      expect(originalBefores).to.deep.equal([
         { fn: requireConfig, args: [] },
-        { fn: requireAuthStub, args: [] },
-      ];
-
-      await expect(
-        command.runner()({
-          package: "@firebase-function-kits/firestore-bigquery-export",
-          cwd: "/mock/project",
-          config: mockConfig,
-          nonInteractive: true,
-        }),
-      ).to.be.rejectedWith(
-        FirebaseError,
-        "Command requires authentication, please run firebase login",
-      );
-
-      expect(installKitOrInstanceStub).not.to.have.been.called;
+        { fn: requireAuth, args: [] },
+      ]);
     });
   });
 
   describe("command action", () => {
-    beforeEach(() => {
-      command["befores"] = [];
-    });
-
     it("should assert that kits experiment is enabled", async () => {
       assertEnabledStub.throws(new FirebaseError("kits experiment disabled"));
 

--- a/src/commands/functions-kits-install.spec.ts
+++ b/src/commands/functions-kits-install.spec.ts
@@ -7,13 +7,16 @@ import * as experiments from "../experiments";
 import { Config } from "../config";
 import { FirebaseError } from "../error";
 import { RC } from "../rc";
+import { requireConfig } from "../requireConfig";
 
 describe("functions:kits:install", () => {
+  const originalBefores = [
+    ...((command as unknown as { befores: Array<{ fn: unknown; args: unknown[] }> }).befores || []),
+  ];
   let assertEnabledStub: sinon.SinonStub;
   let installKitOrInstanceStub: sinon.SinonStub;
 
   beforeEach(() => {
-    (command as unknown as { befores: unknown[] }).befores = [];
     sinon.stub(command, "prepare").resolves();
     assertEnabledStub = sinon.stub(experiments, "assertEnabled");
     installKitOrInstanceStub = sinon.stub(kits, "installKitOrInstance").resolves({
@@ -24,10 +27,62 @@ describe("functions:kits:install", () => {
   });
 
   afterEach(() => {
+    (command as unknown as { befores: unknown[] }).befores = [...originalBefores];
     sinon.restore();
   });
 
+  describe("command prerequisites", () => {
+    it("should throw an error and not start install if requireConfig is not met", async () => {
+      await expect(
+        command.runner()({
+          package: "@firebase-function-kits/firestore-bigquery-export",
+          cwd: "/mock/project",
+          nonInteractive: true,
+        }),
+      ).to.be.rejectedWith(FirebaseError, /could not locate firebase\.json/);
+
+      expect(installKitOrInstanceStub).not.to.have.been.called;
+    });
+
+    it("should throw an error and not start install if requireAuth is not met", async () => {
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: {
+          functions: [],
+        },
+        path: (p: string) => `/mock/project/${p}`,
+      } as unknown as Config;
+
+      const authError = new FirebaseError(
+        "Command requires authentication, please run firebase login",
+      );
+      const requireAuthStub = sinon.stub().rejects(authError);
+      (command as unknown as { befores: unknown[] }).befores = [
+        { fn: requireConfig, args: [] },
+        { fn: requireAuthStub, args: [] },
+      ];
+
+      await expect(
+        command.runner()({
+          package: "@firebase-function-kits/firestore-bigquery-export",
+          cwd: "/mock/project",
+          config: mockConfig,
+          nonInteractive: true,
+        }),
+      ).to.be.rejectedWith(
+        FirebaseError,
+        "Command requires authentication, please run firebase login",
+      );
+
+      expect(installKitOrInstanceStub).not.to.have.been.called;
+    });
+  });
+
   describe("command action", () => {
+    beforeEach(() => {
+      (command as unknown as { befores: unknown[] }).befores = [];
+    });
+
     it("should assert that kits experiment is enabled", async () => {
       assertEnabledStub.throws(new FirebaseError("kits experiment disabled"));
 

--- a/src/commands/functions-kits-install.spec.ts
+++ b/src/commands/functions-kits-install.spec.ts
@@ -10,9 +10,7 @@ import { RC } from "../rc";
 import { requireConfig } from "../requireConfig";
 
 describe("functions:kits:install", () => {
-  const originalBefores = [
-    ...((command as unknown as { befores: Array<{ fn: unknown; args: unknown[] }> }).befores || []),
-  ];
+  const originalBefores = [...(command["befores"] || [])];
   let assertEnabledStub: sinon.SinonStub;
   let installKitOrInstanceStub: sinon.SinonStub;
 
@@ -27,7 +25,7 @@ describe("functions:kits:install", () => {
   });
 
   afterEach(() => {
-    (command as unknown as { befores: unknown[] }).befores = [...originalBefores];
+    command["befores"] = [...originalBefores];
     sinon.restore();
   });
 
@@ -57,7 +55,7 @@ describe("functions:kits:install", () => {
         "Command requires authentication, please run firebase login",
       );
       const requireAuthStub = sinon.stub().rejects(authError);
-      (command as unknown as { befores: unknown[] }).befores = [
+      command["befores"] = [
         { fn: requireConfig, args: [] },
         { fn: requireAuthStub, args: [] },
       ];
@@ -80,7 +78,7 @@ describe("functions:kits:install", () => {
 
   describe("command action", () => {
     beforeEach(() => {
-      (command as unknown as { befores: unknown[] }).befores = [];
+      command["befores"] = [];
     });
 
     it("should assert that kits experiment is enabled", async () => {

--- a/src/commands/functions-kits-install.ts
+++ b/src/commands/functions-kits-install.ts
@@ -3,6 +3,8 @@ import { FirebaseError } from "../error";
 import * as experiments from "../experiments";
 import { Options } from "../options";
 import { installKitOrInstance, TEMPLATES, TemplateType } from "../functions/kits/install";
+import { requireAuth } from "../requireAuth";
+import { requireConfig } from "../requireConfig";
 
 export interface FunctionsKitsInstallOptions extends Options {
   package?: string;
@@ -13,6 +15,8 @@ export interface FunctionsKitsInstallOptions extends Options {
 
 export const command = new Command("functions:kits:install")
   .description("install a function kit into your project")
+  .before(requireConfig)
+  .before(requireAuth)
   .option("--package <package>", "NPM package name or specifier to install as a function kit")
   .option(
     "--directory <directory>",

--- a/src/commands/functions-kits-uninstall.spec.ts
+++ b/src/commands/functions-kits-uninstall.spec.ts
@@ -1,0 +1,63 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+
+import { command } from "./functions-kits-uninstall";
+import { Config } from "../config";
+import { FirebaseError } from "../error";
+import { requireConfig } from "../requireConfig";
+
+describe("functions:kits:uninstall", () => {
+  const originalBefores = [
+    ...((command as unknown as { befores: Array<{ fn: unknown; args: unknown[] }> }).befores || []),
+  ];
+
+  beforeEach(() => {
+    sinon.stub(command, "prepare").resolves();
+  });
+
+  afterEach(() => {
+    (command as unknown as { befores: unknown[] }).befores = [...originalBefores];
+    sinon.restore();
+  });
+
+  describe("command prerequisites", () => {
+    it("should throw an error and not start uninstall if requireConfig is not met", async () => {
+      await expect(
+        command.runner()({
+          kit: "my-kit",
+          cwd: "/mock/project",
+          nonInteractive: true,
+        }),
+      ).to.be.rejectedWith(FirebaseError, /could not locate firebase\.json/);
+    });
+
+    it("should throw an error and not start uninstall if requireAuth is not met", async () => {
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: { functions: [] },
+        path: (p: string) => `/mock/project/${p}`,
+      } as unknown as Config;
+
+      const authError = new FirebaseError(
+        "Command requires authentication, please run firebase login",
+      );
+      const requireAuthStub = sinon.stub().rejects(authError);
+      (command as unknown as { befores: unknown[] }).befores = [
+        { fn: requireConfig, args: [] },
+        { fn: requireAuthStub, args: [] },
+      ];
+
+      await expect(
+        command.runner()({
+          kit: "my-kit",
+          cwd: "/mock/project",
+          config: mockConfig,
+          nonInteractive: true,
+        }),
+      ).to.be.rejectedWith(
+        FirebaseError,
+        "Command requires authentication, please run firebase login",
+      );
+    });
+  });
+});

--- a/src/commands/functions-kits-uninstall.spec.ts
+++ b/src/commands/functions-kits-uninstall.spec.ts
@@ -7,16 +7,14 @@ import { FirebaseError } from "../error";
 import { requireConfig } from "../requireConfig";
 
 describe("functions:kits:uninstall", () => {
-  const originalBefores = [
-    ...((command as unknown as { befores: Array<{ fn: unknown; args: unknown[] }> }).befores || []),
-  ];
+  const originalBefores = [...(command["befores"] || [])];
 
   beforeEach(() => {
     sinon.stub(command, "prepare").resolves();
   });
 
   afterEach(() => {
-    (command as unknown as { befores: unknown[] }).befores = [...originalBefores];
+    command["befores"] = [...originalBefores];
     sinon.restore();
   });
 
@@ -42,7 +40,7 @@ describe("functions:kits:uninstall", () => {
         "Command requires authentication, please run firebase login",
       );
       const requireAuthStub = sinon.stub().rejects(authError);
-      (command as unknown as { befores: unknown[] }).befores = [
+      command["befores"] = [
         { fn: requireConfig, args: [] },
         { fn: requireAuthStub, args: [] },
       ];

--- a/src/commands/functions-kits-uninstall.spec.ts
+++ b/src/commands/functions-kits-uninstall.spec.ts
@@ -1,61 +1,14 @@
 import { expect } from "chai";
-import * as sinon from "sinon";
 
 import { command } from "./functions-kits-uninstall";
-import { Config } from "../config";
-import { FirebaseError } from "../error";
+import { requireAuth } from "../requireAuth";
 import { requireConfig } from "../requireConfig";
 
 describe("functions:kits:uninstall", () => {
-  const originalBefores = [...(command["befores"] || [])];
-
-  beforeEach(() => {
-    sinon.stub(command, "prepare").resolves();
-  });
-
-  afterEach(() => {
-    command["befores"] = [...originalBefores];
-    sinon.restore();
-  });
-
-  describe("command prerequisites", () => {
-    it("should throw an error and not start uninstall if requireConfig is not met", async () => {
-      await expect(
-        command.runner()({
-          kit: "my-kit",
-          cwd: "/mock/project",
-          nonInteractive: true,
-        }),
-      ).to.be.rejectedWith(FirebaseError, /could not locate firebase\.json/);
-    });
-
-    it("should throw an error and not start uninstall if requireAuth is not met", async () => {
-      const mockConfig = {
-        projectDir: "/mock/project",
-        src: { functions: [] },
-        path: (p: string) => `/mock/project/${p}`,
-      } as unknown as Config;
-
-      const authError = new FirebaseError(
-        "Command requires authentication, please run firebase login",
-      );
-      const requireAuthStub = sinon.stub().rejects(authError);
-      command["befores"] = [
-        { fn: requireConfig, args: [] },
-        { fn: requireAuthStub, args: [] },
-      ];
-
-      await expect(
-        command.runner()({
-          kit: "my-kit",
-          cwd: "/mock/project",
-          config: mockConfig,
-          nonInteractive: true,
-        }),
-      ).to.be.rejectedWith(
-        FirebaseError,
-        "Command requires authentication, please run firebase login",
-      );
-    });
+  it("should have requireConfig and requireAuth as before hooks", () => {
+    expect(command["befores"]).to.deep.equal([
+      { fn: requireConfig, args: [] },
+      { fn: requireAuth, args: [] },
+    ]);
   });
 });

--- a/src/commands/functions-kits-uninstall.ts
+++ b/src/commands/functions-kits-uninstall.ts
@@ -1,4 +1,5 @@
 import { requireConfig } from "../requireConfig";
+import { requireAuth } from "../requireAuth";
 import { Command } from "../command";
 import { Config } from "../config";
 import { listKitConfigs } from "../functions/kits/config";
@@ -19,6 +20,7 @@ import { Context } from "../deploy/functions/args";
 export const command = new Command("functions:kits:uninstall")
   .description("uninstall a function kit or kit instance from your project")
   .before(requireConfig)
+  .before(requireAuth)
   .option("--kit <kitId>", "")
   .option("--instance <instanceId>", "")
   .action(async (options: Options): Promise<void> => {


### PR DESCRIPTION
### Description

Adds `requireConfig` and `requireAuth` pre-action hooks to `functions:kits:install`, and `requireAuth` to `functions:kits:uninstall`.

Previously, running `firebase functions:kits:install` without being logged in or with expired credentials allowed kit scaffolding, `npm install`, and build steps to execute before failing mid-prompt with an un-resolvable parameter error. Similarly, `functions:kits:uninstall` could crash midway during deployed Cloud Functions deletion if unauthenticated.

### Scenarios Tested

Unit tests to capture early failure if missing config or authentication.

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
