### PR TITLE
fix(functions): resolve default regions for parameterized event triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- [Fixed] Fix an issue where 2nd-gen functions with parameterized trigger event filters failed default region resolution (#11020).

--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -5,6 +5,7 @@ import * as os from "os";
 import * as path from "path";
 import * as build from "./build";
 import * as prepare from "./prepare";
+import * as params from "./params";
 import * as experiments from "../../experiments";
 import * as runtimes from "./runtimes";
 import * as backend from "./backend";
@@ -630,6 +631,69 @@ describe("prepare", () => {
           expect(want.endpoints["onDocumentCreate"].region).to.deep.equal([expectedRegion]);
         });
       });
+
+      it("resolves region when database location is eur3 with parameterized database", async () => {
+        const want = build.of({
+          onDocumentCreate: {
+            platform: "gcfv2",
+            entryPoint: "entry",
+            project: "project",
+            runtime: latest("nodejs"),
+            eventTrigger: {
+              eventType: "google.cloud.firestore.document.v1.created",
+              eventFilters: { database: "{{ params.DATABASE }}" },
+              retry: false,
+            },
+            region: [build.REGION_TBD],
+          },
+        });
+        const have = backend.empty();
+        const paramValues = {
+          DATABASE: new params.ParamValue("custom-db", false, { string: true }),
+        };
+
+        getDatabaseStub.resolves({ locationId: "eur3" });
+
+        await prepare.resolveDefaultRegionsForBuild(want, have, paramValues);
+
+        const ep = want.endpoints["onDocumentCreate"];
+        expect(ep.region).to.deep.equal(["europe-west1"]);
+        expect(getDatabaseStub).to.have.been.calledWith("project", "custom-db");
+        expect(build.isEventTriggered(ep)).to.be.true;
+        if (build.isEventTriggered(ep)) {
+          expect(ep.eventTrigger.eventFilters).to.deep.equal({ database: "{{ params.DATABASE }}" });
+          expect(ep.eventTrigger.eventFilters?.database).to.equal("{{ params.DATABASE }}");
+        }
+      });
+
+      it("falls back to us-central1 if parameterized trigger database resolution fails", async () => {
+        const want = build.of({
+          onDocumentCreate: {
+            platform: "gcfv2",
+            entryPoint: "entry",
+            project: "project",
+            runtime: latest("nodejs"),
+            eventTrigger: {
+              eventType: "google.cloud.firestore.document.v1.created",
+              eventFilters: { database: "{{ params.UNDEFINED_DB }}" },
+              retry: false,
+            },
+            region: [build.REGION_TBD],
+          },
+        });
+        const have = backend.empty();
+
+        await prepare.resolveDefaultRegionsForBuild(want, have, {});
+
+        const ep = want.endpoints["onDocumentCreate"];
+        expect(ep.region).to.deep.equal(["us-central1"]);
+        expect(build.isEventTriggered(ep)).to.be.true;
+        if (build.isEventTriggered(ep)) {
+          expect(ep.eventTrigger.eventFilters).to.deep.equal({
+            database: "{{ params.UNDEFINED_DB }}",
+          });
+        }
+      });
     });
 
     describe("Storage event triggers", () => {
@@ -664,6 +728,40 @@ describe("prepare", () => {
 
           expect(want.endpoints["onArchive"].region).to.deep.equal([expectedRegion]);
         });
+      });
+
+      it("resolves region when bucket location is eu with parameterized bucket", async () => {
+        const want = build.of({
+          onArchive: {
+            platform: "gcfv2",
+            entryPoint: "entry",
+            project: "project",
+            runtime: latest("nodejs"),
+            eventTrigger: {
+              eventType: "google.cloud.storage.object.v1.archived",
+              eventFilters: { bucket: "{{ params.BUCKET }}" },
+              retry: false,
+            },
+            region: [build.REGION_TBD],
+          },
+        });
+        const have = backend.empty();
+        const paramValues = {
+          BUCKET: new params.ParamValue("custom-bucket", false, { string: true }),
+        };
+
+        getBucketStub.resolves({ location: "eu" });
+
+        await prepare.resolveDefaultRegionsForBuild(want, have, paramValues);
+
+        const ep = want.endpoints["onArchive"];
+        expect(ep.region).to.deep.equal(["europe-west1"]);
+        expect(getBucketStub).to.have.been.calledWith("custom-bucket");
+        expect(build.isEventTriggered(ep)).to.be.true;
+        if (build.isEventTriggered(ep)) {
+          expect(ep.eventTrigger.eventFilters).to.deep.equal({ bucket: "{{ params.BUCKET }}" });
+          expect(ep.eventTrigger.eventFilters?.bucket).to.equal("{{ params.BUCKET }}");
+        }
       });
     });
 

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -7,6 +7,7 @@ import * as experiments from "../../experiments";
 import * as ensureApiEnabled from "../../ensureApiEnabled";
 import * as functionsConfig from "../../functionsConfig";
 import * as functionsEnv from "../../functions/env";
+import * as params from "./params";
 import * as runtimes from "./runtimes";
 import * as supported from "./runtimes/supported";
 import * as validate from "./validate";
@@ -330,29 +331,39 @@ export async function prepare(
     const { userEnvs: userEnvs, secretRefs: secretRefs } = partitionUserEnvs(rawUserEnvs);
     const envs = { ...userEnvs, ...firebaseEnvs };
 
-    const relevantEndpoints = backend
-      .allEndpoints(existingBackend)
-      .filter((e) => e.codebase === codebase || e.codebase === undefined);
-    await resolveDefaultRegionsForBuild(wantBuild, backend.of(...relevantEndpoints));
-
     const parsedSecretRefs = mapObject<string, build.ParsedSecretRef>(secretRefs, (unparsed) =>
       build.parseSecretRef(unparsed),
     );
     build.applyEnvSecretBindings(wantBuild, parsedSecretRefs);
 
-    const {
-      backend: wantBackend,
-      envs: resolvedEnvs,
-      secretRefs: resolvedSecretRefs,
-    } = await build.resolveBackend({
-      build: wantBuild,
-      firebaseConfig,
-      userEnvs,
-      codebase,
-      nonInteractive: options.nonInteractive,
-      force: options.force,
-      isEmulator: false,
-    });
+    // Instead of calling build.resolveBackend() here, we unbundle params.resolveParams()
+    // and build.toBackend() (see #11020).
+    //
+    // Why:
+    // 1) resolveDefaultRegionsForBuild() needs resolved parameter values so trigger event filters
+    //    (e.g., Firestore database or Storage bucket) are not unparsed CEL expressions when querying GCP APIs.
+    // 2) build.toBackend() needs resolved endpoint regions so VPC connector resource strings
+    //    can be formatted with the concrete region (PR #10471).
+    //
+    // Unbundling allows resolveDefaultRegionsForBuild() to sit directly between parameter evaluation
+    // and Backend AST generation.
+    const { paramValues: resolvedEnvs, secretRefs: resolvedSecretRefs } =
+      await params.resolveParams(
+        wantBuild.params,
+        firebaseConfig,
+        build.envWithTypes(wantBuild.params, userEnvs),
+        codebase,
+        options.nonInteractive,
+        options.force,
+        false,
+      );
+
+    const relevantEndpoints = backend
+      .allEndpoints(existingBackend)
+      .filter((e) => e.codebase === codebase || e.codebase === undefined);
+    await resolveDefaultRegionsForBuild(wantBuild, backend.of(...relevantEndpoints), resolvedEnvs);
+
+    const wantBackend = build.toBackend(wantBuild, resolvedEnvs);
 
     functionsEnv.writeResolvedParams(resolvedEnvs, userEnvs, userEnvOpt);
     if (experiments.isEnabled("secretEnvParams")) {
@@ -566,11 +577,17 @@ export async function prepare(
 
 /**
  * Resolves default regions for endpoints in a Build before it is converted to a Backend.
- * This allows the VPC connector string to be built with the correct region in build.ts.
+ * This allows the VPC connector string to be built with the correct region in build.ts (PR #10471).
+ *
+ * Parameter values are accepted here to substitute CEL expressions in trigger event filters
+ * (e.g., parameterized Firestore database or Storage bucket) prior to querying GCP resource APIs (see #11020).
+ * Note that endpoints are not mutated in-place; trigger event filters are resolved ephemerally for service
+ * calls, and build.toBackend remains the sole place where expressions are converted to backend strings.
  */
 export async function resolveDefaultRegionsForBuild(
   buildObj: build.Build,
   have: backend.Backend,
+  paramValues: Record<string, params.ParamValue> = {},
 ): Promise<void> {
   for (const [id, endpoint] of Object.entries(buildObj.endpoints)) {
     if (!endpoint.region?.length || endpoint.region.includes(build.REGION_TBD)) {
@@ -594,8 +611,8 @@ export async function resolveDefaultRegionsForBuild(
       } else {
         // Match triggers.
         try {
-          resolvedRegion = await resolveRegionForTrigger(endpoint);
-        } catch (err: any) {
+          resolvedRegion = await resolveRegionForTrigger(endpoint, paramValues);
+        } catch (err) {
           logger.debug(
             `Failed to resolve region for endpoint ${id}. Defaulting to ${FALLBACK_DEPLOYMENT_REGION}.`,
             getErrStack(err),
@@ -608,9 +625,38 @@ export async function resolveDefaultRegionsForBuild(
   }
 }
 
-async function resolveRegionForTrigger(endpoint: build.Endpoint): Promise<string> {
-  const service = serviceForEndpoint(endpoint);
-  return await service.getDefaultRegion(endpoint);
+/**
+ * Resolves the default region for an endpoint's trigger by calling the appropriate service.
+ * If the endpoint is event-triggered and paramValues are provided, an ephemeral copy with resolved
+ * trigger event filters is passed to the service so that GCP API calls receive concrete values.
+ * The endpoint on the Build object is not mutated; build.toBackend remains the sole place where
+ * expressions are converted to backend strings.
+ */
+async function resolveRegionForTrigger(
+  endpoint: build.Endpoint,
+  paramValues: Record<string, params.ParamValue> = {},
+): Promise<string> {
+  let targetEndpoint = endpoint;
+  if (paramValues && build.isEventTriggered(endpoint)) {
+    targetEndpoint = {
+      ...endpoint,
+      eventTrigger: {
+        ...endpoint.eventTrigger,
+        ...(endpoint.eventTrigger.eventFilters && {
+          eventFilters: mapObject(endpoint.eventTrigger.eventFilters, (v) =>
+            params.resolveString(v, paramValues),
+          ),
+        }),
+        ...(endpoint.eventTrigger.eventFilterPathPatterns && {
+          eventFilterPathPatterns: mapObject(endpoint.eventTrigger.eventFilterPathPatterns, (v) =>
+            params.resolveString(v, paramValues),
+          ),
+        }),
+      },
+    };
+  }
+  const service = serviceForEndpoint(targetEndpoint);
+  return await service.getDefaultRegion(targetEndpoint);
 }
 
 /**


### PR DESCRIPTION
Fixes #11020.

### Description
When 2nd-gen Cloud Functions declare parameterized event trigger filters (such as `database: defineString("DATABASE")` or `bucket: defineString("BUCKET")`), default region resolution failed because parameter evaluation occurred after region resolution. As a result, the CLI passed raw CEL expressions (e.g., `"{{ params.DATABASE }}"`) to GCP Firestore and Storage REST APIs. The APIs rejected these with invalid ID errors, causing the CLI to silently fall back to `us-central1` for functions whose event sources lived in other regions (e.g., `eur3` -> `europe-west1`).

This regression was introduced by PR #10471, which moved region resolution before `build.resolveBackend` to ensure VPC connectors could be built with concrete region paths. However, because `build.resolveBackend` bundled both parameter evaluation (`params.resolveParams`) and backend conversion (`build.toBackend`), parameter resolution was inadvertently moved after region resolution.

#### Fix
We unbundle parameter evaluation from backend conversion so region resolution can sit between them:
1. **Evaluate parameters first**: Parameter values are resolved before default region resolution runs.
2. **Ephemeral trigger lookup**: When querying GCP APIs to discover an event source's region, we ephemerally substitute trigger filter expressions for the API call without mutating the `Build` endpoint in-place.
3. **Pristine AST preservation**: The `Build` endpoint retains its original parameter expressions until `build.toBackend` performs the definitive transformation into a `Backend` object.
4. **Test additions**: Added unit tests in `src/deploy/functions/prepare.spec.ts` covering parameterized Firestore and Storage triggers, asserting that GCP API stubs receive the concrete resolved resource names, the region resolves to the mapped location, and the `Build` endpoint's trigger filters remain completely unmutated.

#### Alternative
An alternative design is to introduce a dedicated `build.resolveEventFilters(wantBuild, paramValues)` step that mutates `eventFilters` directly on the `Build` object before region resolution runs.
- **Tradeoffs**: While this would allow `resolveDefaultRegionsForBuild` to read plain strings without accepting `paramValues`, it introduces an asymmetry where trigger filters are partially resolved on `Build` ahead of time while all other expression fields (`serviceAccount`, `cpu`, `memory`, `vpc`, `schedule`) remain unresolved until `toBackend`. Additionally, `toBackend` must retain filter resolution logic anyway for standalone callers like the emulator.
- We opted for ephemeral resolution to avoid mutating `Build` state and keep `toBackend` as the sole authority for expression evaluation.

### Test Scenarios
- **Parameterized Firestore triggers**: Tested that `database: "{{ params.DATABASE }}"` with `DATABASE=custom-db` in `eur3` resolves the endpoint region to `europe-west1`, passes `"custom-db"` to `getDatabase()`, and verifies `want.endpoints["onDocumentCreate"].eventTrigger.eventFilters` remains unmutated (`{ database: "{{ params.DATABASE }}" }`).
- **Parameterized Storage triggers**: Tested that `bucket: "{{ params.BUCKET }}"` with `BUCKET=custom-bucket` in `eu` resolves the endpoint region to `europe-west1`, passes `"custom-bucket"` to `getBucket()`, and verifies `want.endpoints["onArchive"].eventTrigger.eventFilters` remains unmutated (`{ bucket: "{{ params.BUCKET }}" }`).
- **Error fallback path**: Tested that parameterized triggers with unresolvable/missing parameters gracefully fall back to `us-central1` and leave the trigger filter expressions intact.
- `npm run test`

### Sample Commands
- `firebase deploy --only functions`