### PR TITLE
fix: avoid breaking standalone downloads during release pipeline

### DIFF
--- a/scripts/firepit-builder/pipeline.js
+++ b/scripts/firepit-builder/pipeline.js
@@ -122,25 +122,33 @@ if (isPublishing) {
 
   // 2. Attach standalone artifacts to the draft release created by publish.sh
   shelljs.config.fatal = false;
-  const releaseCheck = exec(`hub release show ${releaseTag}`, { silent: true });
+  const releaseCheck = exec(`hub release show "${releaseTag}"`, { silent: true });
   shelljs.config.fatal = true;
 
   if (releaseCheck.code !== 0) {
     echo(`Release ${releaseTag} not found, creating draft release with standalone artifacts...`);
     const attachArgs = publishedFiles.map((f) => `-a "${path.join("../dist", f)}"`).join(" ");
-    exec(`hub release create --draft -m "${releaseTag}" ${attachArgs} ${releaseTag}`);
+    exec(`hub release create --draft -m "${releaseTag}" ${attachArgs} "${releaseTag}"`);
   } else {
     echo(`Attaching standalone artifacts to release ${releaseTag}...`);
     publishedFiles.forEach((filename) => {
       echo(`Attaching ${filename}...`);
-      hub("release", "edit", "-m", '""', "-a", path.join("../dist", filename), releaseTag);
+      hub(
+        "release",
+        "edit",
+        "-m",
+        '""',
+        "-a",
+        `"${path.join("../dist", filename)}"`,
+        `"${releaseTag}"`,
+      );
     });
   }
 
   // 3. Validate that the draft release has all of the expected artifacts
   echo(`Validating that draft release ${releaseTag} has all expected artifacts...`);
   shelljs.config.fatal = false;
-  const showResult = exec(`hub release show -f "%as" ${releaseTag}`, { silent: true });
+  const showResult = exec(`hub release show -f "%as" "${releaseTag}"`, { silent: true });
   shelljs.config.fatal = true;
 
   if (showResult.code !== 0) {
@@ -149,8 +157,9 @@ if (isPublishing) {
 
   const attachedAssets = showResult.stdout
     .split("\n")
-    .map((s) => s.trim())
-    .filter(Boolean);
+    .map((s) => s.trim().split(/[\t\s]/)[0])
+    .filter(Boolean)
+    .map((url) => path.basename(url));
   echo(`Found attached assets:\n${attachedAssets.map((a) => "  - " + a).join("\n")}`);
 
   const missing = publishedFiles.filter((f) => !attachedAssets.includes(f));
@@ -178,15 +187,16 @@ if (isPublishing) {
           if (matchedRelease && Array.isArray(matchedRelease.assets)) {
             for (const expectedFile of publishedFiles) {
               const asset = matchedRelease.assets.find((a) => a.name === expectedFile);
-              if (asset) {
-                if (asset.state !== "uploaded") {
-                  throw new Error(
-                    `Artifact ${expectedFile} state is "${asset.state}", expected "uploaded".`,
-                  );
-                }
-                if (typeof asset.size === "number" && asset.size <= 0) {
-                  throw new Error(`Artifact ${expectedFile} has invalid size: ${asset.size}`);
-                }
+              if (!asset) {
+                throw new Error(`Artifact ${expectedFile} is missing from GitHub release assets.`);
+              }
+              if (asset.state !== "uploaded") {
+                throw new Error(
+                  `Artifact ${expectedFile} state is "${asset.state}", expected "uploaded".`,
+                );
+              }
+              if (typeof asset.size === "number" && asset.size <= 0) {
+                throw new Error(`Artifact ${expectedFile} has invalid size: ${asset.size}`);
               }
             }
             echo("Artifact upload states and sizes confirmed via GitHub API.");
@@ -194,19 +204,29 @@ if (isPublishing) {
         }
       }
     } catch (apiErr) {
+      if (apiErr.message && apiErr.message.startsWith("Artifact ")) {
+        throw apiErr;
+      }
       echo(`Notice: GitHub API detail check warning: ${apiErr.message}`);
     }
   }
 
   // 4. Publish the draft release
   echo(`Publishing release ${releaseTag}...`);
-  hub("release", "edit", "--draft=false", "-m", '""', releaseTag);
+  hub("release", "edit", "--draft=false", "-m", '""', `"${releaseTag}"`);
   echo(`Successfully published release ${releaseTag}!`);
 
   // 5. Move the npm latest tag
   echo(`Moving npm latest tag to firebase-tools@${packageJson.version}...`);
   const registry = "https://wombat-dressing-room.appspot.com";
-  npm("dist-tag", "add", `firebase-tools@${packageJson.version}`, "latest", "--registry", registry);
+  npm(
+    "dist-tag",
+    "add",
+    `"firebase-tools@${packageJson.version}"`,
+    "latest",
+    "--registry",
+    registry,
+  );
   shelljs.config.fatal = false;
   npm("dist-tag", "rm", "firebase-tools", "staging", "--registry", registry);
   shelljs.config.fatal = true;

--- a/scripts/firepit-builder/pipeline.js
+++ b/scripts/firepit-builder/pipeline.js
@@ -101,7 +101,7 @@ if (styles.headful) {
 }
 
 if (isPublishing) {
-  echo("Publishing...");
+  echo("Publishing standalone artifacts and GitHub release...");
   const publishedFiles = [
     "firebase-tools-instant-win.exe",
     "firebase-tools-linux",
@@ -109,14 +109,109 @@ if (isPublishing) {
     "firebase-tools-win.exe",
   ];
 
+  // 1. Verify all expected artifacts exist in dist
+  publishedFiles.forEach((filename) => {
+    const filePath = path.join("dist", filename);
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`Expected build artifact ${filename} not found at ${filePath}`);
+    }
+  });
+
   hub("clone", "firebase/firebase-tools");
   cd("firebase-tools");
 
-  ls("../dist").forEach((filename) => {
-    if (publishedFiles.indexOf(filename) === -1) return;
-    echo(`Publishing ${filename}...`);
-    hub("release", "edit", "-m", '""', "-a", path.join("../dist", filename), releaseTag);
-  });
+  // 2. Attach standalone artifacts to the draft release created by publish.sh
+  shelljs.config.fatal = false;
+  const releaseCheck = exec(`hub release show ${releaseTag}`, { silent: true });
+  shelljs.config.fatal = true;
+
+  if (releaseCheck.code !== 0) {
+    echo(`Release ${releaseTag} not found, creating draft release with standalone artifacts...`);
+    const attachArgs = publishedFiles.map((f) => `-a "${path.join("../dist", f)}"`).join(" ");
+    exec(`hub release create --draft -m "${releaseTag}" ${attachArgs} ${releaseTag}`);
+  } else {
+    echo(`Attaching standalone artifacts to release ${releaseTag}...`);
+    publishedFiles.forEach((filename) => {
+      echo(`Attaching ${filename}...`);
+      hub("release", "edit", "-m", '""', "-a", path.join("../dist", filename), releaseTag);
+    });
+  }
+
+  // 3. Validate that the draft release has all of the expected artifacts
+  echo(`Validating that draft release ${releaseTag} has all expected artifacts...`);
+  shelljs.config.fatal = false;
+  const showResult = exec(`hub release show -f "%as" ${releaseTag}`, { silent: true });
+  shelljs.config.fatal = true;
+
+  if (showResult.code !== 0) {
+    throw new Error(`Failed to query release ${releaseTag}: ${showResult.stderr}`);
+  }
+
+  const attachedAssets = showResult.stdout
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  echo(`Found attached assets:\n${attachedAssets.map((a) => "  - " + a).join("\n")}`);
+
+  const missing = publishedFiles.filter((f) => !attachedAssets.includes(f));
+  if (missing.length > 0) {
+    throw new Error(
+      `Validation failed! Draft release ${releaseTag} is missing expected artifacts: ${missing.join(", ")}`,
+    );
+  }
+  echo(`All ${publishedFiles.length} expected artifacts verified on draft release ${releaseTag}.`);
+
+  // Verify artifact health via GitHub API if GITHUB_TOKEN is available
+  if (process.env.GITHUB_TOKEN) {
+    try {
+      const repo = process.env.GITHUB_REPOSITORY || "firebase/firebase-tools";
+      shelljs.config.fatal = false;
+      const apiResult = exec(
+        `curl -s -H "Authorization: token ${process.env.GITHUB_TOKEN}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/${repo}/releases"`,
+        { silent: true },
+      );
+      shelljs.config.fatal = true;
+      if (apiResult.code === 0 && apiResult.stdout) {
+        const releases = JSON.parse(apiResult.stdout);
+        if (Array.isArray(releases)) {
+          const matchedRelease = releases.find((r) => r.tag_name === releaseTag);
+          if (matchedRelease && Array.isArray(matchedRelease.assets)) {
+            for (const expectedFile of publishedFiles) {
+              const asset = matchedRelease.assets.find((a) => a.name === expectedFile);
+              if (asset) {
+                if (asset.state !== "uploaded") {
+                  throw new Error(
+                    `Artifact ${expectedFile} state is "${asset.state}", expected "uploaded".`,
+                  );
+                }
+                if (typeof asset.size === "number" && asset.size <= 0) {
+                  throw new Error(`Artifact ${expectedFile} has invalid size: ${asset.size}`);
+                }
+              }
+            }
+            echo("Artifact upload states and sizes confirmed via GitHub API.");
+          }
+        }
+      }
+    } catch (apiErr) {
+      echo(`Notice: GitHub API detail check warning: ${apiErr.message}`);
+    }
+  }
+
+  // 4. Publish the draft release
+  echo(`Publishing release ${releaseTag}...`);
+  hub("release", "edit", "--draft=false", "-m", '""', releaseTag);
+  echo(`Successfully published release ${releaseTag}!`);
+
+  // 5. Move the npm latest tag
+  echo(`Moving npm latest tag to firebase-tools@${packageJson.version}...`);
+  const registry = "https://wombat-dressing-room.appspot.com";
+  npm("dist-tag", "add", `firebase-tools@${packageJson.version}`, "latest", "--registry", registry);
+  shelljs.config.fatal = false;
+  npm("dist-tag", "rm", "firebase-tools", "staging", "--registry", registry);
+  shelljs.config.fatal = true;
+  echo(`Successfully moved npm latest tag to firebase-tools@${packageJson.version}!`);
+
   cd("..");
 } else {
   echo("Skipping publishing...");

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -24,12 +24,16 @@ elif [[ $VERSION == "move-latest" || $VERSION == "tag-latest" ]]; then
   if [[ -z "$TARGET_VERSION" && -f "/workspace/version_number.txt" ]]; then
     TARGET_VERSION=$(cat /workspace/version_number.txt)
   fi
-  if [[ -z "$TARGET_VERSION" ]]; then
+  if [[ -z "$TARGET_VERSION" && -f package.json ]]; then
     TARGET_VERSION=$(jq -r ".version" package.json)
+  fi
+  if [[ -z "$TARGET_VERSION" ]]; then
+    echo "Could not determine target version for move-latest."
+    exit 1
   fi
   echo "Moving npm latest tag to firebase-tools@${TARGET_VERSION}..."
   npm dist-tag add "firebase-tools@${TARGET_VERSION}" latest --registry https://wombat-dressing-room.appspot.com
-  npm dist-tag rm firebase-tools staging --registry https://wombat-dressing-room.appspot.com || true
+  npm dist-tag rm firebase-tools staging --registry https://wombat-dressing-room.appspot.com 2>/dev/null || true
   echo "npm latest tag successfully moved to ${TARGET_VERSION}."
   exit 0
 elif [[ $VERSION == "preview" ]]; then
@@ -37,7 +41,7 @@ elif [[ $VERSION == "preview" ]]; then
     printusage
     exit 1
   fi
-elif [[ ! ($VERSION == "patch" || $VERSION == "minor" || $VERSION == "major" || $VERSION == "move-latest" || $VERSION == "tag-latest") ]]; then
+elif [[ ! ($VERSION == "patch" || $VERSION == "minor" || $VERSION == "major") ]]; then
   printusage
   exit 1
 fi

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -7,7 +7,7 @@ printusage() {
   echo "e.g. REPOSITORY_ORG=user, REPOSITORY_NAME=repo"
   echo ""
   echo "Arguments:"
-  echo "  version: 'patch', 'minor', 'major', 'artifactsOnly', or 'preview'"
+  echo "  version: 'patch', 'minor', 'major', 'artifactsOnly', 'preview', or 'move-latest'"
   echo "  branch: required if version is 'preview'"
 }
 
@@ -19,12 +19,25 @@ if [[ $VERSION == "" ]]; then
 elif [[ $VERSION == "artifactsOnly" ]]; then
   echo "Skipping npm package publish since VERSION is artifactsOnly."
   exit 0
+elif [[ $VERSION == "move-latest" || $VERSION == "tag-latest" ]]; then
+  TARGET_VERSION=$2
+  if [[ -z "$TARGET_VERSION" && -f "/workspace/version_number.txt" ]]; then
+    TARGET_VERSION=$(cat /workspace/version_number.txt)
+  fi
+  if [[ -z "$TARGET_VERSION" ]]; then
+    TARGET_VERSION=$(jq -r ".version" package.json)
+  fi
+  echo "Moving npm latest tag to firebase-tools@${TARGET_VERSION}..."
+  npm dist-tag add "firebase-tools@${TARGET_VERSION}" latest --registry https://wombat-dressing-room.appspot.com
+  npm dist-tag rm firebase-tools staging --registry https://wombat-dressing-room.appspot.com || true
+  echo "npm latest tag successfully moved to ${TARGET_VERSION}."
+  exit 0
 elif [[ $VERSION == "preview" ]]; then
   if [[ $BRANCH == "" ]]; then
     printusage
     exit 1
   fi
-elif [[ ! ($VERSION == "patch" || $VERSION == "minor" || $VERSION == "major") ]]; then
+elif [[ ! ($VERSION == "patch" || $VERSION == "minor" || $VERSION == "major" || $VERSION == "move-latest" || $VERSION == "tag-latest") ]]; then
   printusage
   exit 1
 fi
@@ -134,12 +147,10 @@ echo "" >> "${RELEASE_NOTES_FILE}"
 cat CHANGELOG.md >> "${RELEASE_NOTES_FILE}"
 echo "Made the release notes."
 
-
-
 if [[ $VERSION != "preview" ]]; then
-  echo "Publishing to npm..."
-  npx clean-publish@5.0.0 --before-script ./scripts/clean-shrinkwrap.sh
-  echo "Published to npm."
+  echo "Publishing to npm (under staging tag to avoid moving latest tag)..."
+  npx clean-publish@5.0.0 --before-script ./scripts/clean-shrinkwrap.sh -- --tag staging
+  echo "Published to npm under staging tag."
 
   echo "Updating package-lock.json for Docker image..."
   npm --prefix ./scripts/publish/firebase-docker-image install
@@ -153,7 +164,7 @@ if [[ $VERSION != "preview" ]]; then
   echo "Cleaning up release notes..."
   rm CHANGELOG.md
   touch CHANGELOG.md
-  git commit -m "[firebase-release] Removed change log and reset repo after ${NEW_VERSION} release" CHANGELOG.md scripts/publish/firebase-docker-image/package-lock.json
+  git commit -m "[firebase-release] Removed change log and reset repo after ${NEW_VERSION} release" CHANGELOG.md scripts/publish/firebase-docker-image/package-lock.json src/mcp/server.json
   echo "Cleaned up release notes."
 
   echo "Pushing to GitHub..."

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -7,7 +7,7 @@ printusage() {
   echo "e.g. REPOSITORY_ORG=user, REPOSITORY_NAME=repo"
   echo ""
   echo "Arguments:"
-  echo "  version: 'patch', 'minor', 'major', 'artifactsOnly', 'preview', or 'move-latest'"
+  echo "  version: 'patch', 'minor', 'major', 'artifactsOnly', or 'preview'"
   echo "  branch: required if version is 'preview'"
 }
 
@@ -18,23 +18,6 @@ if [[ $VERSION == "" ]]; then
   exit 1
 elif [[ $VERSION == "artifactsOnly" ]]; then
   echo "Skipping npm package publish since VERSION is artifactsOnly."
-  exit 0
-elif [[ $VERSION == "move-latest" || $VERSION == "tag-latest" ]]; then
-  TARGET_VERSION=$2
-  if [[ -z "$TARGET_VERSION" && -f "/workspace/version_number.txt" ]]; then
-    TARGET_VERSION=$(cat /workspace/version_number.txt)
-  fi
-  if [[ -z "$TARGET_VERSION" && -f package.json ]]; then
-    TARGET_VERSION=$(jq -r ".version" package.json)
-  fi
-  if [[ -z "$TARGET_VERSION" ]]; then
-    echo "Could not determine target version for move-latest."
-    exit 1
-  fi
-  echo "Moving npm latest tag to firebase-tools@${TARGET_VERSION}..."
-  npm dist-tag add "firebase-tools@${TARGET_VERSION}" latest --registry https://wombat-dressing-room.appspot.com
-  npm dist-tag rm firebase-tools staging --registry https://wombat-dressing-room.appspot.com 2>/dev/null || true
-  echo "npm latest tag successfully moved to ${TARGET_VERSION}."
   exit 0
 elif [[ $VERSION == "preview" ]]; then
   if [[ $BRANCH == "" ]]; then

--- a/scripts/publish/cloudbuild.yaml
+++ b/scripts/publish/cloudbuild.yaml
@@ -147,17 +147,38 @@ steps:
           echo "Skipping credentials for firepit-builder for preview."
         fi
 
-  # Publish the firepit builds.
+  # Publish the firepit builds, create draft release with artifacts, validate, publish, and move latest tag.
   - name: "gcr.io/$PROJECT_ID/firepit-builder"
     entrypoint: "bash"
     args:
       - "-c"
       - |
         if [ "${_VERSION}" != "preview" ]; then
-          GITHUB_TOKEN=$(cat ~/.config/hub) node /usr/src/app/pipeline.js --package=firebase-tools@$(cat /workspace/version_number.txt) --publish
-          echo "Please review the draft release notes at https://github.com/${_REPOSITORY_ORG}/${_REPOSITORY_NAME}/releases. If it looks good, publish it"
+          cp -v ${_REPOSITORY_NAME}/scripts/firepit-builder/pipeline.js /usr/src/app/pipeline.js
+          GITHUB_TOKEN=$(cat ~/.config/hub) GITHUB_REPOSITORY="${_REPOSITORY_ORG}/${_REPOSITORY_NAME}" REPOSITORY_ORG="${_REPOSITORY_ORG}" REPOSITORY_NAME="${_REPOSITORY_NAME}" node /usr/src/app/pipeline.js --package=firebase-tools@$(cat /workspace/version_number.txt) --publish
         else
           echo "Skipping firepit build for preview version."
+        fi
+
+  # Verify npm latest tag is pointing to the new version.
+  - name: "gcr.io/$PROJECT_ID/package-builder"
+    entrypoint: "bash"
+    args:
+      - "-c"
+      - |
+        if [ "${_VERSION}" != "preview" ]; then
+          VERSION_NUM="$(cat /workspace/version_number.txt)"
+          echo "Verifying npm latest tag for firebase-tools..."
+          LATEST_TAG=$(npm view firebase-tools dist-tags.latest --registry https://wombat-dressing-room.appspot.com)
+          echo "Current npm latest tag: $${LATEST_TAG}"
+          if [ "$${LATEST_TAG}" != "$${VERSION_NUM}" ]; then
+            echo "Updating npm latest tag to $${VERSION_NUM}..."
+            npm dist-tag add "firebase-tools@$${VERSION_NUM}" latest --registry https://wombat-dressing-room.appspot.com
+            npm dist-tag rm firebase-tools staging --registry https://wombat-dressing-room.appspot.com || true
+          fi
+          echo "Verified npm latest tag is pointing to $${VERSION_NUM}."
+        else
+          echo "Skipping npm latest tag check for preview version."
         fi
 
   # Tag the previous version of the docker image

--- a/scripts/publish/cloudbuild.yaml
+++ b/scripts/publish/cloudbuild.yaml
@@ -174,7 +174,7 @@ steps:
           if [ "$${LATEST_TAG}" != "$${VERSION_NUM}" ]; then
             echo "Updating npm latest tag to $${VERSION_NUM}..."
             npm dist-tag add "firebase-tools@$${VERSION_NUM}" latest --registry https://wombat-dressing-room.appspot.com
-            npm dist-tag rm firebase-tools staging --registry https://wombat-dressing-room.appspot.com || true
+            npm dist-tag rm firebase-tools staging --registry https://wombat-dressing-room.appspot.com 2>/dev/null || true
           fi
           echo "Verified npm latest tag is pointing to $${VERSION_NUM}."
         else


### PR DESCRIPTION
### Description
Refactors the release pipeline to prevent download breakages from firebase.tools during release runs:
1. Publish new version to npm under a staging tag (`--tag staging`) without moving the `latest` dist-tag prematurely.
2. Build standalone artifacts from the new version in the firepit-builder pipeline and attach them to the draft release created by `publish.sh`.
3. Validate that the draft release contains all 4 expected artifacts (`firebase-tools-instant-win.exe`, `firebase-tools-linux`, `firebase-tools-macos`, `firebase-tools-win.exe`) with uploaded states and non-zero sizes before publishing the release.
4. Publish the GitHub release and move the npm `latest` dist-tag to the new version, cleaning up the temporary staging tag.
5. Add verification step in `cloudbuild.yaml`.

### Scenarios Tested
- Ran `bash -n scripts/publish.sh` syntax check.
- Ran `node -c scripts/firepit-builder/pipeline.js` syntax check.
- Checked `scripts/publish/cloudbuild.yaml` YAML parsing and prettier formatting.
- Ran eslint on `scripts/firepit-builder/pipeline.js` and verified clean linting with `npm run lint:changed-files` (0 errors).
- Validated `hub release show -f "%as"` formatting and parsing against live release tag.

### Sample Commands
`./scripts/publish/run.sh patch`
