### PR TITLE
ci: cache VS Code test executable in vscode_unit CI workflow

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -64,6 +64,15 @@ jobs:
           cache: npm
           cache-dependency-path: firebase-vscode/package-lock.json
 
+      - name: Cache VS Code test binary
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # ratchet:actions/cache@v4
+        with:
+          path: firebase-vscode/.vscode-test
+          key: ${{ runner.os }}-vscode-test-${{ hashFiles('firebase-vscode/src/test/constants.ts') }}
+          restore-keys: |
+            ${{ runner.os }}-vscode-test-
+        continue-on-error: true
+
       - run: npm i -g npm@9.5
       - run: npm ci
       - run: npm install


### PR DESCRIPTION
### Description
The VS Code unit tests in CI (`vscode_unit`) currently download the ~130MB VS Code Electron archive from `update.code.visualstudio.com` on every runner invocation. Transient CDN drops or socket terminations (such as `ECONNRESET`) cause intermittent test flakes.

This change adds an `actions/cache` step targeting `firebase-vscode/.vscode-test`, keyed on the OS and the contents of `firebase-vscode/src/test/constants.ts` (where `VSCODE_VERSION` is defined), with a fallback restore key.

### Scenarios Tested
- Verified workflow YAML syntax against GitHub Actions schema.