### PR TITLE
fix(functions): standardize FUNCTION_DEFAULT_REGION and require non-empty input in kit templates

### DIFF
--- a/templates/init/functions/typescript/index-kit-migration.ts
+++ b/templates/init/functions/typescript/index-kit-migration.ts
@@ -17,7 +17,8 @@ import { defineString } from "firebase-functions/params";
 // which is determined at install/deploy time. Use a param whenever you want
 // the value to differ. Learn more at
 // https://firebase.google.com/docs/functions/config-env#params
-export const regionParam = defineString("DEFAULT_FUNCTION_REGION", {
+export const regionParam = defineString("FUNCTION_DEFAULT_REGION", {
+  input: { text: { nonEmpty: true } },
   description: "Global default region where functions should be deployed. Can be overriden per-function.",
 });
 

--- a/templates/init/functions/typescript/index-kit.ts
+++ b/templates/init/functions/typescript/index-kit.ts
@@ -12,6 +12,7 @@ import * as params from "firebase-functions/params";
 // the value to differ. Learn more at
 // https://firebase.google.com/docs/functions/config-env#params
 export const regionParam = params.defineString("FUNCTION_DEFAULT_REGION", {
+  input: { text: { nonEmpty: true } },
   description: "Global default region where functions should be deployed. Can be overriden per-function.",
 });
 


### PR DESCRIPTION
 ### Description
    - Updates `templates/init/functions/typescript/index-kit-migration.ts` to define `FUNCTION_DEFAULT_REGION` instead of `DEFAULT_FUNCTION_REGION`, aligning the migration template with the standard kit template and `ext:export` environment mapping.
    - Configures `input: { text: { nonEmpty: true } }` on `FUNCTION_DEFAULT_REGION` across both standard and migration kit templates to require non-empty values when prompted.

    ### Scenarios Tested
    - npm run test
    - `firebase functions:kits:install --package @firebase-function-kits/storage-resize-images@next --template migration`
    - `firebase functions:kits:install --package @firebase-function-kits/storage-resize-images@next`

    ### Sample Commands
    - `firebase ext:migrate`
    - `firebase functions:kits:install --package @firebase-function-kits/storage-resize-images@next --template migration`