### PR TITLE
fix: allow ext:export to overwrite empty dotenv files created by kits:install

### DIFF
--- a/src/commands/ext-export.spec.ts
+++ b/src/commands/ext-export.spec.ts
@@ -1,3 +1,4 @@
+import * as mockfs from "mock-fs";
 import { expect } from "chai";
 import * as sinon from "sinon";
 
@@ -60,5 +61,85 @@ describe("ext:export secret ejection", () => {
       .resolves({ success: ["foo/bar"], fail: ["baz/qux"] });
     await expect(exportCmd.handleSecretEjection(fakeOptions(true), fakeInstance())).to.not.be
       .rejected;
+  });
+});
+
+describe("hasNonEmptyProjectEnv", () => {
+  afterEach(() => {
+    mockfs.restore();
+  });
+
+  it("returns false if no env files exist in the directory", () => {
+    mockfs({
+      "/project/config": {},
+    });
+    const opts = {
+      functionsSource: "my-inst",
+      configDir: "/project/config",
+      projectId: "my-proj",
+      projectDir: "/project",
+    };
+    expect(exportCmd.hasNonEmptyProjectEnv(opts)).to.be.false;
+  });
+
+  it("returns false if .env.<projectId> exists but has 0 bytes (e.g. from kits:install --no-configure)", () => {
+    mockfs({
+      "/project/config": {
+        ".env.my-proj": "",
+      },
+    });
+    const opts = {
+      functionsSource: "my-inst",
+      configDir: "/project/config",
+      projectId: "my-proj",
+      projectDir: "/project",
+    };
+    expect(exportCmd.hasNonEmptyProjectEnv(opts)).to.be.false;
+  });
+
+  it("returns true if .env.<projectId> exists with non-zero size", () => {
+    mockfs({
+      "/project/config": {
+        ".env.my-proj": "FOO=bar\n",
+      },
+    });
+    const opts = {
+      functionsSource: "my-inst",
+      configDir: "/project/config",
+      projectId: "my-proj",
+      projectDir: "/project",
+    };
+    expect(exportCmd.hasNonEmptyProjectEnv(opts)).to.be.true;
+  });
+
+  it("returns true if .env.<projectAlias> exists with non-zero size", () => {
+    mockfs({
+      "/project/config": {
+        ".env.staging": "FOO=bar\n",
+      },
+    });
+    const opts = {
+      functionsSource: "my-inst",
+      configDir: "/project/config",
+      projectId: "my-proj",
+      projectAlias: "staging",
+      projectDir: "/project",
+    };
+    expect(exportCmd.hasNonEmptyProjectEnv(opts)).to.be.true;
+  });
+
+  it("ignores non-project .env file", () => {
+    mockfs({
+      "/project/config": {
+        ".env": "FOO=bar\n",
+      },
+    });
+    const opts = {
+      functionsSource: "my-inst",
+      configDir: "/project/config",
+      projectId: "my-proj",
+      projectDir: "/project",
+    };
+    expect(exportCmd.hasNonEmptyProjectEnv(opts)).to.be.false;
   });
 });

--- a/src/commands/ext-export.ts
+++ b/src/commands/ext-export.ts
@@ -23,9 +23,9 @@ import { requirePermissions } from "../requirePermissions";
 import { getInstance } from "../extensions/extensionsApi";
 import { last, logLabeledBullet, logLabeledError, logLabeledWarning } from "../utils";
 import { ExtensionInstance } from "../extensions/types";
-import { writeUserEnvs, UserEnvsOpts, hasUserEnvs } from "../functions/env";
-import { mkdirSync } from "fs";
-import { resolve } from "path";
+import { writeUserEnvs, UserEnvsOpts } from "../functions/env";
+import { mkdirSync, statSync } from "fs";
+import { join, resolve } from "path";
 import { Config } from "../config";
 import { normalizeAndValidate, isKitConfig } from "../functions/projectConfig";
 import { FirebaseError } from "../error";
@@ -173,7 +173,9 @@ async function fnHandler(options: Options): Promise<void> {
 
   const convertedEnv = functionsEnvFromInstance(instance);
   const writeLocation: UserEnvsOpts = kitExportTarget(instanceId, projectId, options);
-  if (hasUserEnvs(writeLocation)) {
+  // Function kit installation with `kits:install --no-configure` creates an empty
+  // `.env.<projectId>` file via `fs.ensureFileSync`. We only abort if a non-empty configuration exists.
+  if (hasNonEmptyProjectEnv(writeLocation)) {
     logger.info(
       `Exported extensions config appears to already exist in /${instanceId}, aborting write.`,
     );
@@ -184,6 +186,27 @@ async function fnHandler(options: Options): Promise<void> {
     });
     writeUserEnvs(convertedEnv, writeLocation);
   }
+}
+
+/**
+ * Checks if a project-specific dotenv file exists and is non-empty.
+ * `kits:install --no-configure` creates an empty `.env.<projectId>` file on disk (whereas regular install
+ * populates it), so we only treat the configuration as already existing if the file has non-zero size.
+ */
+export function hasNonEmptyProjectEnv(opts: UserEnvsOpts): boolean {
+  const configDir = opts.configDir || opts.functionsSource;
+  const files = [
+    `.env.${opts.projectId}`,
+    ...(opts.projectAlias ? [`.env.${opts.projectAlias}`] : []),
+  ];
+  return files.some((f) => {
+    const fullPath = join(configDir, f);
+    try {
+      return statSync(fullPath).size > 0;
+    } catch {
+      return false;
+    }
+  });
 }
 
 /**


### PR DESCRIPTION
### Description
`firebase kits:install --no-configure` creates an empty `.env.<projectId>` file. Previously, `ext:export` checked only for file existence on disk, causing it to incorrectly abort when exporting into an unconfigured kit instance. `ext:export` now checks for and ignores empty `.env` files while continuing to safely abort if the files contain configuration content.

Fixes b/556740324

### Scenarios Tested
- Added unit tests in `src/commands/ext-export.spec.ts` verifying empty, populated, missing, and aliased `.env` file handling.
- Manually verified running `ext:export` after `kits:install --no-configure` and verified all tests via `npm test`.

### Sample Commands
```bash
firebase kits:install @firebase-function-kits/storage-resize-images --no-configure
firebase ext:export --mode functions --instance <instanceId> --kit-instance <kitInstanceId>
```
