### PR TITLE
[fix] Allowing functions:delete to remove associated SA created by de…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,4 @@
+- Fixed an issue where `functions:delete` and `functions:kits:uninstall` did not delete declarative security managed service accounts (`firebase-fn-...`) in GCP IAM when all functions using them were removed.
 - Updated the Firebase SQL Connect local toolkit to v3.4.19, which includes the following changes:
   - [fixed] Bug fixes and performance improvements for the PostgreSQL emulator.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
 - Fixed an issue where `functions:delete` and `functions:kits:uninstall` did not delete declarative security managed service accounts (`firebase-fn-...`) in GCP IAM when all functions using them were removed.
 - Updated the Firebase SQL Connect local toolkit to v3.4.19, which includes the following changes:
   - [fixed] Bug fixes and performance improvements for the PostgreSQL emulator.
-

--- a/src/deploy/functions/delete.spec.ts
+++ b/src/deploy/functions/delete.spec.ts
@@ -259,4 +259,46 @@ describe("function delete helper", () => {
     ];
     expect(cleanedSAs).to.have.members([sa1, sa2]);
   });
+
+  it("does not delete managed service account if surviving functions in another region still use it when a region filter is applied", async () => {
+    const sharedSA = "firebase-fn-1234567890@my-project.iam.gserviceaccount.com";
+    const endpointEast: backend.Endpoint = {
+      ...fakeEndpoint,
+      region: "us-east1",
+      serviceAccount: sharedSA,
+    };
+    const endpointCentral: backend.Endpoint = {
+      ...fakeEndpoint2,
+      region: "us-central1",
+      serviceAccount: sharedSA,
+    };
+    const backendMultiRegion: backend.Backend = {
+      requiredAPIs: [],
+      environmentVariables: {},
+      endpoints: {
+        "us-east1": { foo: endpointEast },
+        "us-central1": { bar: endpointCentral },
+      },
+    };
+
+    sinon.stub(backend, "existingBackend").resolves(backendMultiRegion);
+    sinon.stub(functionsConfig, "getFirebaseConfig").resolves({ projectId: "my-project" });
+    sinon.stub(functionsConfig, "getAppEngineLocation").returns("us-central1");
+    sinon.stub(getProjectNumber, "getProjectNumber").resolves("1234");
+    const applyPlanStub = sinon.stub(fabricator.Fabricator.prototype, "applyPlan").resolves({
+      totalTime: 100,
+      results: [{ endpoint: endpointEast, durationMs: 100 }],
+    });
+    sinon.stub(reporter, "logAndTrackDeployStats").resolves();
+
+    // Delete only us-east1 functions; us-central1 functions survive
+    await deleteFunctionsByEndpointFilters(
+      { projectId: "my-project", filters: [{ codebase: "foo" }] },
+      { nonInteractive: true, force: true, region: "us-east1" } as unknown as Options,
+    );
+
+    expect(applyPlanStub.calledOnce).to.be.true;
+    const appliedPlan = applyPlanStub.firstCall.args[0];
+    expect(appliedPlan.default.serviceAccountToDelete).to.be.undefined;
+  });
 });

--- a/src/deploy/functions/delete.spec.ts
+++ b/src/deploy/functions/delete.spec.ts
@@ -134,4 +134,79 @@ describe("function delete helper", () => {
       ),
     ).to.be.rejected;
   });
+
+  it("identifies and passes managed service account for deletion when all functions using it are deleted", async () => {
+    const endpointWithSA: backend.Endpoint = {
+      ...fakeEndpoint,
+      serviceAccount: "firebase-fn-1234567890@my-project.iam.gserviceaccount.com",
+    };
+    const backendWithSA: backend.Backend = {
+      requiredAPIs: [],
+      environmentVariables: {},
+      endpoints: {
+        "us-central1": { foo: endpointWithSA },
+      },
+    };
+
+    sinon.stub(backend, "existingBackend").resolves(backendWithSA);
+    sinon.stub(functionsConfig, "getFirebaseConfig").resolves({ projectId: "my-project" });
+    sinon.stub(functionsConfig, "getAppEngineLocation").returns("us-central1");
+    sinon.stub(getProjectNumber, "getProjectNumber").resolves("1234");
+    const applyPlanStub = sinon.stub(fabricator.Fabricator.prototype, "applyPlan").resolves({
+      totalTime: 100,
+      results: [{ endpoint: endpointWithSA, durationMs: 100 }],
+    });
+    sinon.stub(reporter, "logAndTrackDeployStats").resolves();
+
+    await deleteFunctionsByEndpointFilters(
+      { projectId: "my-project", filters: [{ codebase: "foo" }] },
+      { nonInteractive: true, force: true } as Options,
+    );
+
+    expect(applyPlanStub.calledOnce).to.be.true;
+    const appliedPlan = applyPlanStub.firstCall.args[0];
+    expect(appliedPlan.default.serviceAccountToDelete).to.equal(
+      "firebase-fn-1234567890@my-project.iam.gserviceaccount.com",
+    );
+  });
+
+  it("does not delete managed service account if surviving functions still use it", async () => {
+    const sharedSA = "firebase-fn-1234567890@my-project.iam.gserviceaccount.com";
+    const endpoint1: backend.Endpoint = {
+      ...fakeEndpoint,
+      serviceAccount: sharedSA,
+    };
+    const endpoint2: backend.Endpoint = {
+      ...fakeEndpoint2,
+      codebase: "bar",
+      serviceAccount: sharedSA,
+    };
+    const backendWithSharedSA: backend.Backend = {
+      requiredAPIs: [],
+      environmentVariables: {},
+      endpoints: {
+        "us-central1": { foo: endpoint1, bar: endpoint2 },
+      },
+    };
+
+    sinon.stub(backend, "existingBackend").resolves(backendWithSharedSA);
+    sinon.stub(functionsConfig, "getFirebaseConfig").resolves({ projectId: "my-project" });
+    sinon.stub(functionsConfig, "getAppEngineLocation").returns("us-central1");
+    sinon.stub(getProjectNumber, "getProjectNumber").resolves("1234");
+    const applyPlanStub = sinon.stub(fabricator.Fabricator.prototype, "applyPlan").resolves({
+      totalTime: 100,
+      results: [{ endpoint: endpoint1, durationMs: 100 }],
+    });
+    sinon.stub(reporter, "logAndTrackDeployStats").resolves();
+
+    // Delete only codebase "foo", leaving codebase "bar" (which also uses sharedSA)
+    await deleteFunctionsByEndpointFilters(
+      { projectId: "my-project", filters: [{ codebase: "foo" }] },
+      { nonInteractive: true, force: true } as Options,
+    );
+
+    expect(applyPlanStub.calledOnce).to.be.true;
+    const appliedPlan = applyPlanStub.firstCall.args[0];
+    expect(appliedPlan.default.serviceAccountToDelete).to.be.undefined;
+  });
 });

--- a/src/deploy/functions/delete.spec.ts
+++ b/src/deploy/functions/delete.spec.ts
@@ -209,4 +209,54 @@ describe("function delete helper", () => {
     const appliedPlan = applyPlanStub.firstCall.args[0];
     expect(appliedPlan.default.serviceAccountToDelete).to.be.undefined;
   });
+
+  it("identifies and passes multiple managed service accounts for deletion when functions from multiple codebases are deleted", async () => {
+    const sa1 = "firebase-fn-1111111111@my-project.iam.gserviceaccount.com";
+    const sa2 = "firebase-fn-2222222222@my-project.iam.gserviceaccount.com";
+    const endpoint1: backend.Endpoint = {
+      ...fakeEndpoint,
+      serviceAccount: sa1,
+    };
+    const endpoint2: backend.Endpoint = {
+      ...fakeEndpoint2,
+      codebase: "bar",
+      serviceAccount: sa2,
+    };
+    const backendWithTwoSAs: backend.Backend = {
+      requiredAPIs: [],
+      environmentVariables: {},
+      endpoints: {
+        "us-central1": { foo: endpoint1, bar: endpoint2 },
+      },
+    };
+
+    sinon.stub(backend, "existingBackend").resolves(backendWithTwoSAs);
+    sinon.stub(functionsConfig, "getFirebaseConfig").resolves({ projectId: "my-project" });
+    sinon.stub(functionsConfig, "getAppEngineLocation").returns("us-central1");
+    sinon.stub(getProjectNumber, "getProjectNumber").resolves("1234");
+    const applyPlanStub = sinon.stub(fabricator.Fabricator.prototype, "applyPlan").resolves({
+      totalTime: 200,
+      results: [
+        { endpoint: endpoint1, durationMs: 100 },
+        { endpoint: endpoint2, durationMs: 100 },
+      ],
+    });
+    sinon.stub(reporter, "logAndTrackDeployStats").resolves();
+
+    await deleteFunctionsByEndpointFilters(
+      {
+        projectId: "my-project",
+        filters: [{ codebase: "foo" }, { codebase: "bar" }],
+      },
+      { nonInteractive: true, force: true } as Options,
+    );
+
+    expect(applyPlanStub.calledOnce).to.be.true;
+    const appliedPlan = applyPlanStub.firstCall.args[0];
+    const cleanedSAs = [
+      appliedPlan.default.serviceAccountToDelete,
+      appliedPlan["cleanup-sa-1"]?.serviceAccountToDelete,
+    ];
+    expect(cleanedSAs).to.have.members([sa1, sa2]);
+  });
 });

--- a/src/deploy/functions/delete.ts
+++ b/src/deploy/functions/delete.ts
@@ -29,7 +29,8 @@ export async function deleteFunctionsByEndpointFilters(
   context: Context,
   options?: Options,
 ): Promise<number> {
-  let haveBackend = await backend.existingBackend(context);
+  const fullBackend = await backend.existingBackend(context);
+  let haveBackend = fullBackend;
   if (options?.region) {
     haveBackend = backend.matchingBackend(
       haveBackend,
@@ -62,14 +63,14 @@ export async function deleteFunctionsByEndpointFilters(
   );
 
   // If all functions utilizing a managed service account are being deleted (i.e. no surviving
-  // endpoints in haveBackend still reference it), mark that service account for deletion.
+  // endpoints in fullBackend across all regions still reference it), mark that service account for deletion.
   // This prevents orphaned service accounts from accumulating in GCP IAM upon codebase deletion
   // or kit uninstallation, and avoids stale reference errors during subsequent reinstalls.
   const existingManagedSAs: string[] = [];
   if (deletedManagedSAs.size > 0) {
     const deletedIds = new Set(allEpToDelete.map((del) => `${del.region}/${del.id}`));
     const survivingEndpoints = backend
-      .allEndpoints(haveBackend)
+      .allEndpoints(fullBackend)
       .filter((e) => !deletedIds.has(`${e.region}/${e.id}`));
     const survivingSAs = new Set(survivingEndpoints.map((e) => e.serviceAccount));
     for (const sa of deletedManagedSAs) {

--- a/src/deploy/functions/delete.ts
+++ b/src/deploy/functions/delete.ts
@@ -36,7 +36,7 @@ export async function deleteFunctionsByEndpointFilters(
       (endpoint) => endpoint.region === options.region,
     );
   }
-  const plan = await planner.createDeploymentPlan({
+  const initialPlan = await planner.createDeploymentPlan({
     wantBackend: backend.empty(),
     haveBackend: haveBackend,
     codebase: "",
@@ -44,13 +44,49 @@ export async function deleteFunctionsByEndpointFilters(
     filters: context.filters,
     deleteAll: true,
   });
-  const allEpToDelete = Object.values(plan.regionalChangesets)
+  const allEpToDelete = Object.values(initialPlan.regionalChangesets)
     .map((changes) => changes.endpointsToDelete)
     .reduce(reduceFlat, [])
     .sort(backend.compareFunctions);
   if (allEpToDelete.length === 0) {
     return 0;
   }
+
+  // Discover any managed service accounts (firebase-fn-*) used by endpoints slated for deletion.
+  // When declarative security (requiresRole) is used, the CLI synthesizes and manages these service
+  // accounts exclusively for the functions in that codebase.
+  const deletedManagedSAs = new Set(
+    allEpToDelete
+      .map((e) => e.serviceAccount)
+      .filter((sa): sa is string => typeof sa === "string" && sa.startsWith("firebase-fn-")),
+  );
+
+  // If all functions utilizing a managed service account are being deleted (i.e. no surviving
+  // endpoints in haveBackend still reference it), mark that service account for deletion.
+  // This prevents orphaned service accounts from accumulating in GCP IAM upon codebase deletion
+  // or kit uninstallation, and avoids stale reference errors during subsequent reinstalls.
+  let existingManagedSA: string | undefined;
+  if (deletedManagedSAs.size > 0) {
+    const survivingEndpoints = backend
+      .allEndpoints(haveBackend)
+      .filter((e) => !allEpToDelete.some((del) => del.id === e.id && del.region === e.region));
+    const survivingSAs = new Set(survivingEndpoints.map((e) => e.serviceAccount));
+    existingManagedSA = Array.from(deletedManagedSAs).find((sa) => !survivingSAs.has(sa));
+  }
+
+  // If a managed service account is ready for cleanup, regenerate the deployment plan with
+  // existingManagedSA populated so planner sets serviceAccountToDelete and fabricator deletes it.
+  const plan = existingManagedSA
+    ? await planner.createDeploymentPlan({
+        wantBackend: backend.empty(),
+        haveBackend: haveBackend,
+        codebase: "",
+        projectId: context.projectId,
+        filters: context.filters,
+        deleteAll: true,
+        existingManagedSA,
+      })
+    : initialPlan;
 
   const deleteList = allEpToDelete.map((func) => `\t${getFunctionLabel(func)}`).join("\n");
   const confirmDeletion = await confirm({

--- a/src/deploy/functions/delete.ts
+++ b/src/deploy/functions/delete.ts
@@ -36,7 +36,7 @@ export async function deleteFunctionsByEndpointFilters(
       (endpoint) => endpoint.region === options.region,
     );
   }
-  const initialPlan = await planner.createDeploymentPlan({
+  const plan = await planner.createDeploymentPlan({
     wantBackend: backend.empty(),
     haveBackend: haveBackend,
     codebase: "",
@@ -44,7 +44,7 @@ export async function deleteFunctionsByEndpointFilters(
     filters: context.filters,
     deleteAll: true,
   });
-  const allEpToDelete = Object.values(initialPlan.regionalChangesets)
+  const allEpToDelete = Object.values(plan.regionalChangesets)
     .map((changes) => changes.endpointsToDelete)
     .reduce(reduceFlat, [])
     .sort(backend.compareFunctions);
@@ -65,28 +65,23 @@ export async function deleteFunctionsByEndpointFilters(
   // endpoints in haveBackend still reference it), mark that service account for deletion.
   // This prevents orphaned service accounts from accumulating in GCP IAM upon codebase deletion
   // or kit uninstallation, and avoids stale reference errors during subsequent reinstalls.
-  let existingManagedSA: string | undefined;
+  const existingManagedSAs: string[] = [];
   if (deletedManagedSAs.size > 0) {
+    const deletedIds = new Set(allEpToDelete.map((del) => `${del.region}/${del.id}`));
     const survivingEndpoints = backend
       .allEndpoints(haveBackend)
-      .filter((e) => !allEpToDelete.some((del) => del.id === e.id && del.region === e.region));
+      .filter((e) => !deletedIds.has(`${e.region}/${e.id}`));
     const survivingSAs = new Set(survivingEndpoints.map((e) => e.serviceAccount));
-    existingManagedSA = Array.from(deletedManagedSAs).find((sa) => !survivingSAs.has(sa));
+    for (const sa of deletedManagedSAs) {
+      if (!survivingSAs.has(sa)) {
+        existingManagedSAs.push(sa);
+      }
+    }
   }
 
-  // If a managed service account is ready for cleanup, regenerate the deployment plan with
-  // existingManagedSA populated so planner sets serviceAccountToDelete and fabricator deletes it.
-  const plan = existingManagedSA
-    ? await planner.createDeploymentPlan({
-        wantBackend: backend.empty(),
-        haveBackend: haveBackend,
-        codebase: "",
-        projectId: context.projectId,
-        filters: context.filters,
-        deleteAll: true,
-        existingManagedSA,
-      })
-    : initialPlan;
+  if (existingManagedSAs.length > 0) {
+    plan.serviceAccountToDelete = existingManagedSAs[0];
+  }
 
   const deleteList = allEpToDelete.map((func) => `\t${getFunctionLabel(func)}`).join("\n");
   const confirmDeletion = await confirm({
@@ -122,7 +117,15 @@ export async function deleteFunctionsByEndpointFilters(
       projectNumber: await getProjectNumber({ projectId: context.projectId }),
       projectId: context.projectId,
     });
-    const summary = await fab.applyPlan({ default: plan });
+    const deploymentPlan: Record<string, planner.CodebasePlan> = { default: plan };
+    for (let i = 1; i < existingManagedSAs.length; i++) {
+      deploymentPlan[`cleanup-sa-${i}`] = {
+        regionalChangesets: {},
+        plannedBackend: backend.empty(),
+        serviceAccountToDelete: existingManagedSAs[i],
+      };
+    }
+    const summary = await fab.applyPlan(deploymentPlan);
 
     await reporter.logAndTrackDeployStats(summary);
     reporter.printErrors(summary);


### PR DESCRIPTION
### Description
Deletes declarative security managed service accounts (`firebase-fn-...`) in GCP IAM when running `firebase functions:delete` or `firebase functions:kits:uninstall`.
### Context
When a codebase uses declarative security (`requiresRole`), the CLI provisions a dedicated service account (`firebase-fn-...`).
While `firebase deploy` was previously updated to clean up this service account when all functions in a codebase were removed, the explicit deletion flow (`deleteFunctionsByEndpointFilters` in `delete.ts`) omitted `existingManagedSA` when calling the planner.
Because `functions:delete <codebase>` and `functions:kits:uninstall` route through `delete.ts`, Cloud Functions were removed from GCP, but the managed Service Account was left behind in IAM. This caused orphan service accounts to accumulate over install/uninstall cycles and led to stale reference errors (`404/400 Service Account does not exist`) if a user cleaned up permissions manually.
### Key Changes
- In `src/deploy/functions/delete.ts`, identify any managed service accounts (`firebase-fn-*`) attached to endpoints slated for deletion.
- Verify that no surviving functions in the project still reference that service account (to ensure partial/single-function deletions do not delete shared SAs prematurely).
- If all functions using the managed SA are being removed, pass `existingManagedSA` to `planner.createDeploymentPlan()`, allowing `fabricator.ts` to delete the service account in GCP IAM.
- Added unit tests in `src/deploy/functions/delete.spec.ts` covering both full codebase deletion and partial function deletion scenarios.
### Testing
- **Unit Tests**: `npx mocha src/deploy/functions/delete.spec.ts` (`6 passing`).
- **Live E2E Verification**: Verified live on GCP project (`varun-test-project-auth` & `varun-extensions-new`), confirming that the Cloud Functions and their associated managed Service Account (`firebase-fn-...`) are deleted cleanly.