### PR TITLE
fix(functions): clean up managed service accounts on codebase deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Updated the Firebase SQL Connect local toolkit to v3.4.19, which includes the following changes:
   - [fixed] Bug fixes and performance improvements for the PostgreSQL emulator.
+- [fixed] Clean up managed service accounts when all functions in a codebase are deleted.

--- a/src/deploy/functions/delete.spec.ts
+++ b/src/deploy/functions/delete.spec.ts
@@ -3,11 +3,13 @@ import * as sinon from "sinon";
 
 import * as backend from "./backend";
 import * as fabricator from "./release/fabricator";
+import * as planner from "./release/planner";
 import { deleteFunctionsByEndpointFilters } from "./delete";
 import { Options } from "../../options";
 import * as functionsConfig from "../../functionsConfig";
 import * as reporter from "./release/reporter";
 import * as getProjectNumber from "../../getProjectNumber";
+import * as prompt from "../../prompt";
 
 describe("function delete helper", () => {
   const fakeEndpoint: backend.Endpoint = {
@@ -19,13 +21,6 @@ describe("function delete helper", () => {
     entryPoint: "function",
     codebase: "foo",
   };
-  const fakeBackend: backend.Backend = {
-    requiredAPIs: [],
-    environmentVariables: {},
-    endpoints: {
-      "us-central1": { foo: fakeEndpoint },
-    },
-  };
   const fakeEndpoint2: backend.Endpoint = {
     id: "bar",
     region: "us-central1",
@@ -35,103 +30,223 @@ describe("function delete helper", () => {
     entryPoint: "function",
     codebase: "foo",
   };
-  const fakeBackendWithBoth: backend.Backend = {
-    requiredAPIs: [],
-    environmentVariables: {},
-    endpoints: {
-      "us-central1": { foo: fakeEndpoint, bar: fakeEndpoint2 },
-    },
-  };
+
+  let applyPlanStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    sinon.stub(functionsConfig, "getFirebaseConfig").resolves({ projectId: "my-project" });
+    sinon.stub(functionsConfig, "getAppEngineLocation").returns("us-central1");
+    sinon.stub(getProjectNumber, "getProjectNumber").resolves("1234");
+    sinon.stub(reporter, "logAndTrackDeployStats").resolves();
+    applyPlanStub = sinon
+      .stub(fabricator.Fabricator.prototype, "applyPlan")
+      .resolves({ totalTime: 100, results: [] });
+  });
 
   afterEach(() => {
     sinon.restore();
   });
 
   it("calls the fabricator to implement a deletion plan", async () => {
-    sinon.stub(backend, "existingBackend").resolves(fakeBackend);
-    sinon.stub(functionsConfig, "getFirebaseConfig").resolves({ projectId: "my-project" });
-    sinon.stub(functionsConfig, "getAppEngineLocation").returns("us-central1");
-    sinon.stub(getProjectNumber, "getProjectNumber").resolves("1234");
-    sinon.stub(fabricator.Fabricator.prototype, "applyPlan").resolves({
-      totalTime: 100,
-      results: [
-        {
-          endpoint: fakeEndpoint,
-          durationMs: 100,
-        },
-      ],
-    });
-    sinon.stub(reporter, "logAndTrackDeployStats").resolves();
+    sinon.stub(backend, "existingBackend").resolves(backend.of(fakeEndpoint));
 
     await expect(
       deleteFunctionsByEndpointFilters(
         { projectId: "my-project", filters: [{ codebase: "foo" }] },
-        {
-          nonInteractive: true,
-          force: true,
-        } as Options,
+        { nonInteractive: true, force: true } as Options,
+      ),
+    ).to.eventually.equal(1);
+  });
+
+  it("defaults endpoints without codebase to DEFAULT_CODEBASE", async () => {
+    const defaultEndpoint: backend.Endpoint = {
+      ...fakeEndpoint,
+      codebase: undefined,
+    };
+    sinon.stub(backend, "existingBackend").resolves(backend.of(defaultEndpoint));
+
+    await expect(
+      deleteFunctionsByEndpointFilters(
+        { projectId: "my-project", filters: [{ codebase: "default" }] },
+        { nonInteractive: true, force: true } as Options,
       ),
     ).to.eventually.equal(1);
   });
 
   it("short-circuits and returns 0 if the provided filter doesn't match", async () => {
-    sinon.stub(backend, "existingBackend").resolves(fakeBackend);
+    sinon.stub(backend, "existingBackend").resolves(backend.of(fakeEndpoint));
 
     await expect(
       deleteFunctionsByEndpointFilters(
         { projectId: "my-project", filters: [{ codebase: "asdf" }] },
-        {
-          nonInteractive: true,
-          force: true,
-        } as Options,
+        { nonInteractive: true, force: true } as Options,
       ),
     ).to.eventually.equal(0);
   });
 
   it("removes functions from consideration if they don't match a provided --region flag", async () => {
-    sinon.stub(backend, "existingBackend").resolves(fakeBackend);
+    sinon.stub(backend, "existingBackend").resolves(backend.of(fakeEndpoint));
 
     await expect(
       deleteFunctionsByEndpointFilters(
         { projectId: "my-project", filters: [{ codebase: "foo" }] },
-        {
-          nonInteractive: true,
-          force: true,
-          region: "us-east1",
-        } as unknown as Options,
+        { nonInteractive: true, force: true, region: "us-east1" } as unknown as Options,
       ),
     ).to.eventually.equal(0);
   });
 
   it("throws an error if any delete op fails", async () => {
-    sinon.stub(backend, "existingBackend").resolves(fakeBackendWithBoth);
-    sinon.stub(functionsConfig, "getFirebaseConfig").resolves({ projectId: "my-project" });
-    sinon.stub(functionsConfig, "getAppEngineLocation").returns("us-central1");
-    sinon.stub(getProjectNumber, "getProjectNumber").resolves("1234");
-    sinon.stub(fabricator.Fabricator.prototype, "applyPlan").resolves({
+    sinon.stub(backend, "existingBackend").resolves(backend.of(fakeEndpoint, fakeEndpoint2));
+    applyPlanStub.resolves({
       totalTime: 200,
       results: [
-        {
-          endpoint: fakeEndpoint,
-          durationMs: 100,
-        },
-        {
-          endpoint: fakeEndpoint2,
-          durationMs: 100,
-          error: new Error("something went wrong"),
-        },
+        { endpoint: fakeEndpoint, durationMs: 100 },
+        { endpoint: fakeEndpoint2, durationMs: 100, error: new Error("something went wrong") },
       ],
     });
-    sinon.stub(reporter, "logAndTrackDeployStats").resolves();
 
     await expect(
       deleteFunctionsByEndpointFilters(
         { projectId: "my-project", filters: [{ codebase: "foo" }] },
-        {
-          nonInteractive: true,
-          force: true,
-        } as Options,
+        { nonInteractive: true, force: true } as Options,
       ),
     ).to.be.rejected;
+  });
+
+  it("aborts deletion when confirmation prompt is rejected", async () => {
+    sinon.stub(backend, "existingBackend").resolves(backend.of(fakeEndpoint));
+    sinon.stub(prompt, "confirm").resolves(false);
+
+    await expect(
+      deleteFunctionsByEndpointFilters(
+        { projectId: "my-project", filters: [{ codebase: "foo" }] },
+        { nonInteractive: false, force: false } as Options,
+      ),
+    ).to.be.rejectedWith("Command aborted.");
+
+    expect(applyPlanStub).to.not.have.been.called;
+  });
+
+  describe("declarative security cleanup", () => {
+    const managedSA = "firebase-fn-123@my-project.iam.gserviceaccount.com";
+    const managedEndpoint1: backend.Endpoint = {
+      ...fakeEndpoint,
+      codebase: "my-codebase",
+      serviceAccount: managedSA,
+    };
+    const managedEndpoint2: backend.Endpoint = {
+      ...fakeEndpoint2,
+      id: "func2",
+      codebase: "my-codebase",
+      serviceAccount: managedSA,
+    };
+    const managedEndpointEast: backend.Endpoint = {
+      ...fakeEndpoint,
+      id: "func3",
+      region: "us-east1",
+      codebase: "my-codebase",
+      serviceAccount: managedSA,
+    };
+
+    it("schedules managed service account deletion when all functions in a codebase are deleted", async () => {
+      sinon
+        .stub(backend, "existingBackend")
+        .resolves(backend.of(managedEndpoint1, managedEndpoint2));
+
+      await deleteFunctionsByEndpointFilters(
+        { projectId: "my-project", filters: [{ codebase: "my-codebase" }] },
+        { nonInteractive: true, force: true } as Options,
+      );
+
+      const plan = applyPlanStub.firstCall.args[0] as planner.DeploymentPlan;
+      expect(plan["my-codebase"]?.serviceAccountToDelete).to.equal(managedSA);
+    });
+
+    it("does not schedule managed service account deletion on partial codebase deletion", async () => {
+      sinon
+        .stub(backend, "existingBackend")
+        .resolves(backend.of(managedEndpoint1, managedEndpoint2));
+
+      await deleteFunctionsByEndpointFilters(
+        {
+          projectId: "my-project",
+          filters: [{ codebase: "my-codebase", idChunks: ["foo"] }],
+        },
+        { nonInteractive: true, force: true } as Options,
+      );
+
+      const plan = applyPlanStub.firstCall.args[0] as planner.DeploymentPlan;
+      expect(plan["my-codebase"]?.serviceAccountToDelete).to.be.undefined;
+    });
+
+    it("does not schedule managed service account deletion when deletion is restricted by --region and other regions still have functions", async () => {
+      sinon
+        .stub(backend, "existingBackend")
+        .resolves(backend.of(managedEndpoint1, managedEndpointEast));
+
+      await deleteFunctionsByEndpointFilters(
+        { projectId: "my-project", filters: [{ codebase: "my-codebase" }] },
+        { nonInteractive: true, force: true, region: "us-central1" } as unknown as Options,
+      );
+
+      const plan = applyPlanStub.firstCall.args[0] as planner.DeploymentPlan;
+      expect(plan["my-codebase"]?.serviceAccountToDelete).to.be.undefined;
+    });
+
+    it("handles multiple codebases independently when scheduling service account deletions", async () => {
+      const sa1 = "firebase-fn-111@my-project.iam.gserviceaccount.com";
+      const sa2 = "firebase-fn-222@my-project.iam.gserviceaccount.com";
+      const cb1Endpoint: backend.Endpoint = {
+        ...fakeEndpoint,
+        codebase: "cb1",
+        serviceAccount: sa1,
+      };
+      const cb2Endpoint1: backend.Endpoint = {
+        ...fakeEndpoint2,
+        id: "fn2",
+        codebase: "cb2",
+        serviceAccount: sa2,
+      };
+      const cb2Endpoint2: backend.Endpoint = {
+        ...fakeEndpoint2,
+        id: "fn3",
+        codebase: "cb2",
+        serviceAccount: sa2,
+      };
+
+      sinon
+        .stub(backend, "existingBackend")
+        .resolves(backend.of(cb1Endpoint, cb2Endpoint1, cb2Endpoint2));
+
+      // Delete all of cb1 and only fn2 from cb2
+      await deleteFunctionsByEndpointFilters(
+        {
+          projectId: "my-project",
+          filters: [{ codebase: "cb1" }, { codebase: "cb2", idChunks: ["fn2"] }],
+        },
+        { nonInteractive: true, force: true } as Options,
+      );
+
+      const plan = applyPlanStub.firstCall.args[0] as planner.DeploymentPlan;
+      expect(plan["cb1"]?.serviceAccountToDelete).to.equal(sa1);
+      expect(plan["cb2"]?.serviceAccountToDelete).to.be.undefined;
+    });
+
+    it("includes managed service accounts in confirmation prompt message", async () => {
+      sinon.stub(backend, "existingBackend").resolves(backend.of(managedEndpoint1));
+      const confirmStub = sinon.stub(prompt, "confirm").resolves(true);
+
+      await deleteFunctionsByEndpointFilters(
+        { projectId: "my-project", filters: [{ codebase: "my-codebase" }] },
+        {} as Options,
+      );
+
+      expect(confirmStub).to.have.been.calledOnce;
+      const promptArg = confirmStub.firstCall.args[0] as { message: string };
+      expect(promptArg.message).to.include(
+        "The following managed service accounts will also be deleted:",
+      );
+      expect(promptArg.message).to.include(managedSA);
+    });
   });
 });

--- a/src/deploy/functions/delete.ts
+++ b/src/deploy/functions/delete.ts
@@ -2,15 +2,15 @@ import * as backend from "./backend";
 import * as planner from "./release/planner";
 import * as executor from "./release/executor";
 import * as fabricator from "./release/fabricator";
-import { getFunctionLabel } from "./functionsDeployHelper";
+import { getFunctionLabel, endpointMatchesAnyFilter } from "./functionsDeployHelper";
 import { getProjectNumber } from "../../getProjectNumber";
 import * as reporter from "./release/reporter";
+import * as prompt from "../../prompt";
+import * as functionsConfig from "../../functionsConfig";
 import { Context } from "./args";
 import { FirebaseError } from "../../error";
-import { reduceFlat } from "../../functional";
-import { confirm } from "../../prompt";
 import { Options } from "../../options";
-import * as functionsConfig from "../../functionsConfig";
+import { DEFAULT_CODEBASE } from "../../functions/projectConfig";
 
 /**
  * Deletes Functions based on the provided EndpointFilter, which
@@ -29,33 +29,73 @@ export async function deleteFunctionsByEndpointFilters(
   context: Context,
   options?: Options,
 ): Promise<number> {
-  let haveBackend = await backend.existingBackend(context);
-  if (options?.region) {
-    haveBackend = backend.matchingBackend(
-      haveBackend,
-      (endpoint) => endpoint.region === options.region,
+  const allExistingBackend = await backend.existingBackend(context);
+  const targetedRegionBackend = options?.region
+    ? backend.matchingBackend(allExistingBackend, (endpoint) => endpoint.region === options.region)
+    : allExistingBackend;
+
+  const codebases = new Set(
+    backend.allEndpoints(allExistingBackend).map((ep) => ep.codebase || DEFAULT_CODEBASE),
+  );
+
+  const deploymentPlan: planner.DeploymentPlan = {};
+  for (const codebase of codebases) {
+    const allCodebaseBackend = backend.matchingBackend(
+      allExistingBackend,
+      (ep) => (ep.codebase || DEFAULT_CODEBASE) === codebase,
     );
+    const targetedCodebaseBackend = backend.matchingBackend(
+      targetedRegionBackend,
+      (ep) => (ep.codebase || DEFAULT_CODEBASE) === codebase,
+    );
+
+    const totalEndpointsInGcp = backend.allEndpoints(allCodebaseBackend);
+    const endpointsToDelete = backend
+      .allEndpoints(targetedCodebaseBackend)
+      .filter((e) => endpointMatchesAnyFilter(e, context.filters));
+
+    let existingManagedSA: string | undefined;
+    if (endpointsToDelete.length > 0 && endpointsToDelete.length === totalEndpointsInGcp.length) {
+      const ep = totalEndpointsInGcp.find(
+        (e) => typeof e.serviceAccount === "string" && e.serviceAccount.startsWith("firebase-fn-"),
+      );
+      existingManagedSA = ep?.serviceAccount ?? undefined;
+    }
+
+    deploymentPlan[codebase] = await planner.createDeploymentPlan({
+      wantBackend: backend.empty(),
+      haveBackend: targetedCodebaseBackend,
+      codebase,
+      projectId: context.projectId,
+      filters: context.filters,
+      deleteAll: true,
+      existingManagedSA,
+    });
   }
-  const plan = await planner.createDeploymentPlan({
-    wantBackend: backend.empty(),
-    haveBackend: haveBackend,
-    codebase: "",
-    projectId: context.projectId,
-    filters: context.filters,
-    deleteAll: true,
-  });
-  const allEpToDelete = Object.values(plan.regionalChangesets)
-    .map((changes) => changes.endpointsToDelete)
-    .reduce(reduceFlat, [])
+
+  const allEpToDelete = Object.values(deploymentPlan)
+    .flatMap((plan) =>
+      Object.values(plan.regionalChangesets).flatMap((changes) => changes.endpointsToDelete),
+    )
     .sort(backend.compareFunctions);
   if (allEpToDelete.length === 0) {
     return 0;
   }
 
   const deleteList = allEpToDelete.map((func) => `\t${getFunctionLabel(func)}`).join("\n");
-  const confirmDeletion = await confirm({
-    message:
-      "You are about to delete the following Cloud Functions:\n" + deleteList + "\n  Are you sure?",
+  const saToDelete = Object.values(deploymentPlan)
+    .map((p) => p.serviceAccountToDelete)
+    .filter((sa): sa is string => !!sa);
+
+  let message = "You are about to delete the following Cloud Functions:\n" + deleteList;
+  if (saToDelete.length > 0) {
+    const saList = saToDelete.map((sa) => `\t${sa}`).join("\n");
+    message += "\n\nThe following managed service accounts will also be deleted:\n" + saList;
+  }
+  message += "\n  Are you sure?";
+
+  const confirmDeletion = await prompt.confirm({
+    message,
     default: false,
     force: options?.force,
     nonInteractive: options?.nonInteractive,
@@ -86,7 +126,7 @@ export async function deleteFunctionsByEndpointFilters(
       projectNumber: await getProjectNumber({ projectId: context.projectId }),
       projectId: context.projectId,
     });
-    const summary = await fab.applyPlan({ default: plan });
+    const summary = await fab.applyPlan(deploymentPlan);
 
     await reporter.logAndTrackDeployStats(summary);
     reporter.printErrors(summary);
@@ -95,8 +135,9 @@ export async function deleteFunctionsByEndpointFilters(
     }
     return allEpToDelete.length;
   } catch (err: unknown) {
-    throw new FirebaseError(`Failed to delete functions: ${err}`, {
-      original: err as Error,
+    const message = err instanceof Error ? err.message : String(err);
+    throw new FirebaseError(`Failed to delete functions: ${message}`, {
+      original: err instanceof Error ? err : undefined,
       exit: 1,
     });
   }

--- a/src/deploy/functions/delete.ts
+++ b/src/deploy/functions/delete.ts
@@ -15,10 +15,12 @@ import { DEFAULT_CODEBASE } from "../../functions/projectConfig";
 /**
  * Deletes Functions based on the provided EndpointFilter, which
  * allows deleting all functions that match a specific codebase, ID
- * prefix, or both.
+ * prefix, or both. Also cleans up any declarative security managed
+ * service accounts when all functions in a codebase are deleted.
  *
- * Asks for confirmation before delete. If CLI options are passed,
- * respects force and nonInteractive.
+ * Asks for confirmation before delete (including any managed service
+ * accounts slated for deletion). If CLI options are passed, respects
+ * force and nonInteractive.
  *
  * Returns the number of functions deleted. Awaits the success or failure
  * of all delete operations before throwing if any operation failed.
@@ -57,9 +59,10 @@ export async function deleteFunctionsByEndpointFilters(
     let existingManagedSA: string | undefined;
     if (endpointsToDelete.length > 0 && endpointsToDelete.length === totalEndpointsInGcp.length) {
       const ep = totalEndpointsInGcp.find(
-        (e) => typeof e.serviceAccount === "string" && e.serviceAccount.startsWith("firebase-fn-"),
+        (e): e is backend.Endpoint & { serviceAccount: string } =>
+          typeof e.serviceAccount === "string" && e.serviceAccount.startsWith("firebase-fn-"),
       );
-      existingManagedSA = ep?.serviceAccount ?? undefined;
+      existingManagedSA = ep?.serviceAccount;
     }
 
     deploymentPlan[codebase] = await planner.createDeploymentPlan({


### PR DESCRIPTION
### Description
When deleting a codebase configured with declarative security, the associated managed service account (firebase-fn-...@<projectId>.iam.gserviceaccount.com) was previously left behind in GCP IAM.

This change aligns functions:delete with deploy by partitioning the deletion plan across real codebases and passing existingManagedSA to planner.createDeploymentPlan, delegating deletion to fabricator.applyPlan when all functions across all regions in the codebase are removed. It also surfaces any managed service accounts slated for deletion in the user confirmation prompt.

### Scenarios Tested
- **Unit tests**: Verified full deletion schedules service account cleanup, partial/cross-region deletions preserve it, multi-codebase plans are handled independently, and prompt warnings/aborts work as expected.
- **Manual tests**: Tested firebase functions:delete and firebase functions:kits:uninstall against codebases with declarative security to verify prompt warnings and IAM service account deletion.

### Sample Commands
firebase functions:delete --codebase my-codebase
firebase functions:kits:uninstall my-kit-instance
firebase functions:delete --codebase my-codebase --region us-central1
