### PR TITLE
docs(extensions): align EVENTARC_CHANNEL export comment in ext:export

### DIFF
--- a/src/commands/ext-export.ts
+++ b/src/commands/ext-export.ts
@@ -61,7 +61,7 @@ export const command = new Command("ext:export")
       // - explicitly sets unspecified user params to the empty string instead of leaving them out (and causing a prompt on first deploy)
       // - coerces system param naming format to be valid .env keys (e.g EXT_MIGRATED_SYSTEM_MEMORY=256 instead of firebaseextensions.v1beta.function/memory=256)
       // - writes references to secrets in the Functions format (e.g FIREBASE_SECRET_REF_API_KEY=foo:latest instead of API_KEY=projects/${param:PROJECT_NUMBER}/secrets/API_KEY/versions/latest)
-      // - makes DeploymentInstanceSpec.eventarcChannel and allowedEventTypes available as FIREBASE_EVENTARC_CHANNEL and EXT_SELECTED_EVENTS
+      // - makes DeploymentInstanceSpec.eventarcChannel and allowedEventTypes available as EVENTARC_CHANNEL and EXT_SELECTED_EVENTS
       await fnHandler(options);
     } else {
       // Extensions handler:


### PR DESCRIPTION
### Description
Updates code documentation in `src/commands/ext-export.ts` to reference `EVENTARC_CHANNEL` rather than `FIREBASE_EVENTARC_CHANNEL`. This aligns the comment with the actual exported environment variable format from `functionsEnvFromInstance` and what is expected by extension kits (matching `EVENTARC_CHANNEL` in `firebase/extensions`).

### Scenarios Tested
- Unit tests pass: `npx mocha src/commands/ext-export.spec.ts src/extensions/export.spec.ts`
- Lint checks pass: `npm run lint:changed-files`

### Sample Commands
```bash
firebase ext:export --mode functions --instance <instanceId>
```
