### PR TITLE
fix(gcp): retry on IAM replication lag and etag conflicts in resourceManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Repurposed the local `dataconnect_execute` tool as `dataconnect_execute_in_emulator` to run GraphQL queries and mutations on the local SQL Connect emulator.
 - Configured the SQL Connect (Data Connect) OneMCP proxy server in `ONEMCP_SERVERS` with a selection of remote tools.
 - Configured the `Mcp-Param-Region` HTTP header workaround in `OneMcpServer` for MCP routing support.
+- [fixed] Retry IAM policy updates on replication lag and concurrency conflicts.

--- a/src/gcp/iam.spec.ts
+++ b/src/gcp/iam.spec.ts
@@ -10,6 +10,10 @@ const BINDING = {
 };
 
 describe("iam", () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
   describe("mergeBindings", () => {
     it("should not update the policy when the bindings are present", () => {
       const policy = {
@@ -106,10 +110,6 @@ describe("iam", () => {
     const EMAIL = `${ACCOUNT_ID}@${PROJECT_ID}.iam.gserviceaccount.com`;
     const DISPLAY_NAME = "Test Account";
     const DESCRIPTION = "Test Description";
-
-    afterEach(() => {
-      nock.cleanAll();
-    });
 
     describe("createServiceAccount", () => {
       it("should create a service account", async () => {

--- a/src/gcp/resourceManager.spec.ts
+++ b/src/gcp/resourceManager.spec.ts
@@ -61,6 +61,7 @@ function mockSetIamPolicy(
 describe("resourceManager", () => {
   afterEach(() => {
     nock.cleanAll();
+    sinon.restore();
   });
 
   describe("addServiceAccountToRoles", () => {
@@ -176,6 +177,20 @@ describe("resourceManager", () => {
 
       await expect(addServiceAccountToRoles(PROJECT_ID, SA_EMAIL, ["roles/viewer"], true)).to.be
         .rejected;
+    });
+
+    it("should fail immediately on 400 error when role does not exist without retrying", async () => {
+      mockGetIamPolicy(EMPTY_POLICY);
+      mockSetIamPolicy(400, {
+        error: {
+          code: 400,
+          message: "Role roles/nonexistent does not exist.",
+          status: "INVALID_ARGUMENT",
+        },
+      });
+
+      await expect(addServiceAccountToRoles(PROJECT_ID, SA_EMAIL, ["roles/nonexistent"], true)).to
+        .be.rejected;
     });
   });
 

--- a/src/gcp/resourceManager.spec.ts
+++ b/src/gcp/resourceManager.spec.ts
@@ -1,6 +1,9 @@
+import * as sinon from "sinon";
 import { expect } from "chai";
 
+import { resourceManagerOrigin } from "../api";
 import nock from "../test/helpers/nock";
+import * as utils from "../utils";
 import {
   addServiceAccountToRoles,
   serviceAccountHasRoles,
@@ -12,8 +15,48 @@ import { Policy } from "./iam";
 
 const PROJECT_ID = "test-project";
 const SERVICE_ACCOUNT_NAME = "test-sa";
-const FULL_SA_NAME = `projects/${PROJECT_ID}/serviceAccounts/${SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com`;
-const MEMBER_NAME = `serviceAccount:${SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com`;
+const SA_EMAIL = `${SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com`;
+const FULL_SA_NAME = `projects/${PROJECT_ID}/serviceAccounts/${SA_EMAIL}`;
+const MEMBER_NAME = `serviceAccount:${SA_EMAIL}`;
+
+const EMPTY_POLICY: Policy = {
+  bindings: [],
+  etag: "etag",
+  version: 1,
+};
+
+const VIEWER_POLICY: Policy = {
+  bindings: [
+    {
+      role: "roles/viewer",
+      members: [MEMBER_NAME],
+    },
+  ],
+  etag: "etag",
+  version: 1,
+};
+
+function mockGetIamPolicy(policy: Policy = EMPTY_POLICY, projectId = PROJECT_ID): void {
+  nock(resourceManagerOrigin()).post(`/v1/projects/${projectId}:getIamPolicy`).reply(200, policy);
+}
+
+function mockSetIamPolicy(
+  status: number,
+  response: Policy | Record<string, unknown>,
+  expectedPolicy?: Policy,
+  projectId = PROJECT_ID,
+): void {
+  nock(resourceManagerOrigin())
+    .post(
+      `/v1/projects/${projectId}:setIamPolicy`,
+      expectedPolicy
+        ? (body: { updateMask?: string; policy?: Policy }) =>
+            body.updateMask === "bindings" &&
+            JSON.stringify(body.policy) === JSON.stringify(expectedPolicy)
+        : undefined,
+    )
+    .reply(status, response);
+}
 
 describe("resourceManager", () => {
   afterEach(() => {
@@ -21,83 +64,34 @@ describe("resourceManager", () => {
   });
 
   describe("addServiceAccountToRoles", () => {
+    const origRetryWithBackoff = utils.retryWithBackoff;
+    let retryStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      retryStub = sinon
+        .stub(utils, "retryWithBackoff")
+        .callsFake((fn, opts) => origRetryWithBackoff(fn, { ...opts, delay: 1, maxDelay: 5 }));
+    });
+
+    afterEach(() => {
+      retryStub.restore();
+    });
     it("should add roles when skipAccountLookup is true", async () => {
-      const initialPolicy: Policy = {
-        bindings: [],
-        etag: "etag",
-        version: 1,
-      };
+      mockGetIamPolicy(EMPTY_POLICY);
+      mockSetIamPolicy(200, VIEWER_POLICY, VIEWER_POLICY);
 
-      const expectedPolicy: Policy = {
-        bindings: [
-          {
-            role: "roles/viewer",
-            members: [MEMBER_NAME],
-          },
-        ],
-        etag: "etag",
-        version: 1,
-      };
+      const result = await addServiceAccountToRoles(PROJECT_ID, SA_EMAIL, ["roles/viewer"], true);
 
-      nock("https://cloudresourcemanager.googleapis.com")
-        .post(`/v1/projects/${PROJECT_ID}:getIamPolicy`)
-        .reply(200, initialPolicy);
-
-      nock("https://cloudresourcemanager.googleapis.com")
-        .post(`/v1/projects/${PROJECT_ID}:setIamPolicy`, (body: any) => {
-          return (
-            body.updateMask === "bindings" &&
-            JSON.stringify(body.policy) === JSON.stringify(expectedPolicy)
-          );
-        })
-        .reply(200, expectedPolicy);
-
-      const result = await addServiceAccountToRoles(
-        PROJECT_ID,
-        `${SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com`,
-        ["roles/viewer"],
-        true,
-      );
-
-      expect(result).to.deep.equal(expectedPolicy);
+      expect(result).to.deep.equal(VIEWER_POLICY);
     });
 
     it("should add roles when skipAccountLookup is false", async () => {
-      const initialPolicy: Policy = {
-        bindings: [],
-        etag: "etag",
-        version: 1,
-      };
-
-      const expectedPolicy: Policy = {
-        bindings: [
-          {
-            role: "roles/viewer",
-            members: [MEMBER_NAME],
-          },
-        ],
-        etag: "etag",
-        version: 1,
-      };
-
       nock("https://iam.googleapis.com")
-        .get(
-          `/v1/projects/${PROJECT_ID}/serviceAccounts/${SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com`,
-        )
+        .get(`/v1/projects/${PROJECT_ID}/serviceAccounts/${SA_EMAIL}`)
         .reply(200, { name: FULL_SA_NAME });
 
-      nock("https://cloudresourcemanager.googleapis.com")
-        .post(`/v1/projects/${PROJECT_ID}:getIamPolicy`)
-        .reply(200, initialPolicy);
-
-      nock("https://cloudresourcemanager.googleapis.com")
-        .post(`/v1/projects/${PROJECT_ID}:setIamPolicy`, (body: any) => {
-          return (
-            body.updateMask === "bindings" &&
-            JSON.stringify(body.policy) === JSON.stringify(expectedPolicy)
-          );
-        })
-        .reply(200, expectedPolicy);
+      mockGetIamPolicy(EMPTY_POLICY);
+      mockSetIamPolicy(200, VIEWER_POLICY, VIEWER_POLICY);
 
       const result = await addServiceAccountToRoles(
         PROJECT_ID,
@@ -106,42 +100,82 @@ describe("resourceManager", () => {
         false,
       );
 
-      expect(result).to.deep.equal(expectedPolicy);
+      expect(result).to.deep.equal(VIEWER_POLICY);
     });
 
     it("should not duplicate roles if already present", async () => {
-      const initialPolicy: Policy = {
-        bindings: [
-          {
-            role: "roles/viewer",
-            members: [MEMBER_NAME],
-          },
-        ],
-        etag: "etag",
-        version: 1,
-      };
+      mockGetIamPolicy(VIEWER_POLICY);
+      mockSetIamPolicy(200, VIEWER_POLICY, VIEWER_POLICY);
 
-      nock("https://cloudresourcemanager.googleapis.com")
-        .post(`/v1/projects/${PROJECT_ID}:getIamPolicy`)
-        .reply(200, initialPolicy);
+      const result = await addServiceAccountToRoles(PROJECT_ID, SA_EMAIL, ["roles/viewer"], true);
 
-      nock("https://cloudresourcemanager.googleapis.com")
-        .post(`/v1/projects/${PROJECT_ID}:setIamPolicy`, (body: any) => {
-          return (
-            body.updateMask === "bindings" &&
-            JSON.stringify(body.policy) === JSON.stringify(initialPolicy)
-          );
-        })
-        .reply(200, initialPolicy);
+      expect(result).to.deep.equal(VIEWER_POLICY);
+    });
 
-      const result = await addServiceAccountToRoles(
-        PROJECT_ID,
-        `${SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com`,
-        ["roles/viewer"],
-        true,
-      );
+    it("should retry and succeed when setIamPolicy initially fails with 400 'does not exist' error", async () => {
+      const expectedPolicy = { ...VIEWER_POLICY, etag: "etag2" };
 
-      expect(result).to.deep.equal(initialPolicy);
+      mockGetIamPolicy(EMPTY_POLICY);
+      mockSetIamPolicy(400, {
+        error: {
+          code: 400,
+          message: `Service account ${SA_EMAIL} does not exist.`,
+          status: "INVALID_ARGUMENT",
+        },
+      });
+      mockGetIamPolicy(EMPTY_POLICY);
+      mockSetIamPolicy(200, expectedPolicy);
+
+      const result = await addServiceAccountToRoles(PROJECT_ID, SA_EMAIL, ["roles/viewer"], true);
+
+      expect(result).to.deep.equal(expectedPolicy);
+    });
+
+    it("should retry and succeed when setIamPolicy initially fails with 409 conflict", async () => {
+      const expectedPolicy = { ...VIEWER_POLICY, etag: "etag2" };
+
+      mockGetIamPolicy(EMPTY_POLICY);
+      mockSetIamPolicy(409, {
+        error: {
+          code: 409,
+          message: "There were concurrent policy changes.",
+          status: "ABORTED",
+        },
+      });
+      mockGetIamPolicy(EMPTY_POLICY);
+      mockSetIamPolicy(200, expectedPolicy);
+
+      const result = await addServiceAccountToRoles(PROJECT_ID, SA_EMAIL, ["roles/viewer"], true);
+
+      expect(result).to.deep.equal(expectedPolicy);
+    });
+
+    it("should fail immediately on 403 permission error without retrying", async () => {
+      mockGetIamPolicy(EMPTY_POLICY);
+      mockSetIamPolicy(403, {
+        error: {
+          code: 403,
+          message: "The caller does not have permission",
+          status: "PERMISSION_DENIED",
+        },
+      });
+
+      await expect(addServiceAccountToRoles(PROJECT_ID, SA_EMAIL, ["roles/viewer"], true)).to.be
+        .rejected;
+    });
+
+    it("should fail immediately on 404 not found error without retrying", async () => {
+      mockGetIamPolicy(EMPTY_POLICY);
+      mockSetIamPolicy(404, {
+        error: {
+          code: 404,
+          message: "Project does not exist",
+          status: "NOT_FOUND",
+        },
+      });
+
+      await expect(addServiceAccountToRoles(PROJECT_ID, SA_EMAIL, ["roles/viewer"], true)).to.be
+        .rejected;
     });
   });
 
@@ -162,13 +196,11 @@ describe("resourceManager", () => {
         version: 1,
       };
 
-      nock("https://cloudresourcemanager.googleapis.com")
-        .post(`/v1/projects/${PROJECT_ID}:getIamPolicy`)
-        .reply(200, policy);
+      mockGetIamPolicy(policy);
 
       const result = await serviceAccountHasRoles(
         PROJECT_ID,
-        `${SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com`,
+        SA_EMAIL,
         ["roles/viewer", "roles/editor"],
         true,
       );
@@ -188,13 +220,11 @@ describe("resourceManager", () => {
         version: 1,
       };
 
-      nock("https://cloudresourcemanager.googleapis.com")
-        .post(`/v1/projects/${PROJECT_ID}:getIamPolicy`)
-        .reply(200, policy);
+      mockGetIamPolicy(policy);
 
       const result = await serviceAccountHasRoles(
         PROJECT_ID,
-        `${SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com`,
+        SA_EMAIL,
         ["roles/viewer", "roles/editor"],
         true,
       );
@@ -214,16 +244,9 @@ describe("resourceManager", () => {
         version: 1,
       };
 
-      nock("https://cloudresourcemanager.googleapis.com")
-        .post(`/v1/projects/${PROJECT_ID}:getIamPolicy`)
-        .reply(200, policy);
+      mockGetIamPolicy(policy);
 
-      const result = await serviceAccountHasRoles(
-        PROJECT_ID,
-        `${SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com`,
-        ["roles/viewer"],
-        true,
-      );
+      const result = await serviceAccountHasRoles(PROJECT_ID, SA_EMAIL, ["roles/viewer"], true);
 
       expect(result).to.be.false;
     });
@@ -246,24 +269,13 @@ describe("resourceManager", () => {
         version: 1,
       };
 
-      nock("https://cloudresourcemanager.googleapis.com")
-        .post(`/v1/projects/${PROJECT_ID}:getIamPolicy`)
-        .reply(200, initialPolicy);
+      mockGetIamPolicy(initialPolicy);
+      mockSetIamPolicy(200, expectedPolicy, expectedPolicy);
 
-      nock("https://cloudresourcemanager.googleapis.com")
-        .post(`/v1/projects/${PROJECT_ID}:setIamPolicy`, (body: any) => {
-          return (
-            body.updateMask === "bindings" &&
-            JSON.stringify(body.policy) === JSON.stringify(expectedPolicy)
-          );
-        })
-        .reply(200, expectedPolicy);
-
-      const result = await removeServiceAccountRoles(
-        PROJECT_ID,
-        `${SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com`,
-        ["roles/viewer", "roles/editor"],
-      );
+      const result = await removeServiceAccountRoles(PROJECT_ID, SA_EMAIL, [
+        "roles/viewer",
+        "roles/editor",
+      ]);
 
       expect(result).to.deep.equal(expectedPolicy);
     });
@@ -281,14 +293,9 @@ describe("resourceManager", () => {
         version: 1,
       };
 
-      nock("https://cloudresourcemanager.googleapis.com")
-        .post(`/v1/projects/${PROJECT_ID}:getIamPolicy`)
-        .reply(200, policy);
+      mockGetIamPolicy(policy);
 
-      const roles = await getServiceAccountRoles(
-        PROJECT_ID,
-        `${SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com`,
-      );
+      const roles = await getServiceAccountRoles(PROJECT_ID, SA_EMAIL);
       expect(roles).to.deep.equal(["roles/role1", "roles/role3"]);
     });
   });

--- a/src/gcp/resourceManager.ts
+++ b/src/gcp/resourceManager.ts
@@ -1,4 +1,3 @@
-import { findIndex } from "lodash";
 import { resourceManagerOrigin } from "../api";
 import { Client } from "../apiv2";
 import { getErrMsg, getErrStatus } from "../error";
@@ -61,7 +60,8 @@ function isRetryableIamError(err: unknown): boolean {
     return true;
   }
   const msg = getErrMsg(err).toLowerCase();
-  if (status === 400 && msg.includes("does not exist")) {
+  const hasSa = msg.includes("service account") || msg.includes("serviceaccount");
+  if (status === 400 && hasSa && msg.includes("does not exist")) {
     return true;
   }
   return false;
@@ -81,47 +81,36 @@ export async function addServiceAccountToRoles(
   roles: string[],
   skipAccountLookup = false,
 ): Promise<Policy> {
+  const { name: fullServiceAccountName } = skipAccountLookup
+    ? { name: serviceAccountName }
+    : await getServiceAccount(projectId, serviceAccountName);
+
+  // The way the service account name is formatted in the Policy object
+  // https://cloud.google.com/iam/docs/reference/rest/v1/Policy
+  // serviceAccount:my-project-id@appspot.gserviceaccount.com
+  const newMemberName = `serviceAccount:${fullServiceAccountName.split("/").pop()}`;
+
   // Service accounts are typically assigned roles immediately after creation. Due to cross-region
   // IAM replication delay, Cloud Resource Manager setIamPolicy can transiently fail with HTTP 400
   // ("Service account ... does not exist"). Retrying absorbs this replication window and also
   // handles HTTP 409 concurrency conflicts by re-fetching the latest policy and fresh etag.
   return await utils.retryWithBackoff(
     async () => {
-      const [{ name: fullServiceAccountName }, projectPolicy] = await Promise.all([
-        skipAccountLookup
-          ? Promise.resolve({ name: serviceAccountName })
-          : getServiceAccount(projectId, serviceAccountName),
-        getIamPolicy(projectId),
-      ]);
+      const projectPolicy = await getIamPolicy(projectId);
       projectPolicy.bindings = projectPolicy.bindings || [];
 
-      // The way the service account name is formatted in the Policy object
-      // https://cloud.google.com/iam/docs/reference/rest/v1/Policy
-      // serviceAccount:my-project-id@appspot.gserviceaccount.com
-      const newMemberName = `serviceAccount:${fullServiceAccountName.split("/").pop()}`;
-
-      roles.forEach((roleName) => {
-        let bindingIndex = findIndex(
-          projectPolicy.bindings,
-          (binding: Binding) => binding.role === roleName,
-        );
+      for (const roleName of roles) {
+        let binding = projectPolicy.bindings.find((b: Binding) => b.role === roleName);
 
         // create a new binding if the role doesn't exist in the policy yet
-        if (bindingIndex === -1) {
-          bindingIndex =
-            projectPolicy.bindings.push({
-              role: roleName,
-              members: [],
-            }) - 1;
+        if (!binding) {
+          binding = { role: roleName, members: [] };
+          projectPolicy.bindings.push(binding);
         }
-
-        const binding = projectPolicy.bindings[bindingIndex];
-
-        // No need to update if service account already has role
         if (!binding.members.includes(newMemberName)) {
           binding.members.push(newMemberName);
         }
-      });
+      }
 
       return await setIamPolicy(projectId, projectPolicy, "bindings");
     },

--- a/src/gcp/resourceManager.ts
+++ b/src/gcp/resourceManager.ts
@@ -1,6 +1,8 @@
 import { findIndex } from "lodash";
 import { resourceManagerOrigin } from "../api";
 import { Client } from "../apiv2";
+import { getErrMsg, getErrStatus } from "../error";
+import * as utils from "../utils";
 import { Binding, getServiceAccount, Policy } from "./iam";
 
 const API_VERSION = "v1";
@@ -53,12 +55,25 @@ export async function setIamPolicy(
   return response.body;
 }
 
+function isRetryableIamError(err: unknown): boolean {
+  const status = getErrStatus(err);
+  if (status === 409) {
+    return true;
+  }
+  const msg = getErrMsg(err).toLowerCase();
+  if (status === 400 && msg.includes("does not exist")) {
+    return true;
+  }
+  return false;
+}
+
 /**
  * Update the IAM Policy of a project to include a service account in a role.
  *
  * @param projectId the id of the project whose IAM Policy you want to set
  * @param serviceAccountName the name of the service account
  * @param roles the new roles of the service account
+ * @param skipAccountLookup whether to skip fetching the full service account details
  */
 export async function addServiceAccountToRoles(
   projectId: string,
@@ -66,44 +81,57 @@ export async function addServiceAccountToRoles(
   roles: string[],
   skipAccountLookup = false,
 ): Promise<Policy> {
-  const [{ name: fullServiceAccountName }, projectPolicy] = await Promise.all([
-    skipAccountLookup
-      ? Promise.resolve({ name: serviceAccountName })
-      : getServiceAccount(projectId, serviceAccountName),
-    getIamPolicy(projectId),
-  ]);
+  // Service accounts are typically assigned roles immediately after creation. Due to cross-region
+  // IAM replication delay, Cloud Resource Manager setIamPolicy can transiently fail with HTTP 400
+  // ("Service account ... does not exist"). Retrying absorbs this replication window and also
+  // handles HTTP 409 concurrency conflicts by re-fetching the latest policy and fresh etag.
+  return await utils.retryWithBackoff(
+    async () => {
+      const [{ name: fullServiceAccountName }, projectPolicy] = await Promise.all([
+        skipAccountLookup
+          ? Promise.resolve({ name: serviceAccountName })
+          : getServiceAccount(projectId, serviceAccountName),
+        getIamPolicy(projectId),
+      ]);
+      projectPolicy.bindings = projectPolicy.bindings || [];
 
-  projectPolicy.bindings = projectPolicy.bindings || [];
+      // The way the service account name is formatted in the Policy object
+      // https://cloud.google.com/iam/docs/reference/rest/v1/Policy
+      // serviceAccount:my-project-id@appspot.gserviceaccount.com
+      const newMemberName = `serviceAccount:${fullServiceAccountName.split("/").pop()}`;
 
-  // The way the service account name is formatted in the Policy object
-  // https://cloud.google.com/iam/docs/reference/rest/v1/Policy
-  // serviceAccount:my-project-id@appspot.gserviceaccount.com
-  const newMemberName = `serviceAccount:${fullServiceAccountName.split("/").pop()}`;
+      roles.forEach((roleName) => {
+        let bindingIndex = findIndex(
+          projectPolicy.bindings,
+          (binding: Binding) => binding.role === roleName,
+        );
 
-  roles.forEach((roleName) => {
-    let bindingIndex = findIndex(
-      projectPolicy.bindings,
-      (binding: Binding) => binding.role === roleName,
-    );
+        // create a new binding if the role doesn't exist in the policy yet
+        if (bindingIndex === -1) {
+          bindingIndex =
+            projectPolicy.bindings.push({
+              role: roleName,
+              members: [],
+            }) - 1;
+        }
 
-    // create a new binding if the role doesn't exist in the policy yet
-    if (bindingIndex === -1) {
-      bindingIndex =
-        projectPolicy.bindings.push({
-          role: roleName,
-          members: [],
-        }) - 1;
-    }
+        const binding = projectPolicy.bindings[bindingIndex];
 
-    const binding = projectPolicy.bindings[bindingIndex];
+        // No need to update if service account already has role
+        if (!binding.members.includes(newMemberName)) {
+          binding.members.push(newMemberName);
+        }
+      });
 
-    // No need to update if service account already has role
-    if (!binding.members.includes(newMemberName)) {
-      binding.members.push(newMemberName);
-    }
-  });
-
-  return setIamPolicy(projectId, projectPolicy, "bindings");
+      return await setIamPolicy(projectId, projectPolicy, "bindings");
+    },
+    {
+      retries: 6,
+      delay: 1000,
+      maxDelay: 5000,
+      retryPredicate: isRetryableIamError,
+    },
+  );
 }
 
 export async function serviceAccountHasRoles(

--- a/src/gcp/resourceManager.ts
+++ b/src/gcp/resourceManager.ts
@@ -2,7 +2,7 @@ import { resourceManagerOrigin } from "../api";
 import { Client } from "../apiv2";
 import { getErrMsg, getErrStatus } from "../error";
 import * as utils from "../utils";
-import { Binding, getServiceAccount, Policy } from "./iam";
+import { Binding, getServiceAccount, mergeBindings, Policy } from "./iam";
 
 const API_VERSION = "v1";
 
@@ -54,6 +54,23 @@ export async function setIamPolicy(
   return response.body;
 }
 
+/**
+ * Determines whether an IAM policy modification error is transient and safe to retry.
+ *
+ * Retried errors:
+ * 1. HTTP 409 (ABORTED): Policy update conflict ("There were concurrent policy changes.").
+ *    Occurs when another operation updates the IAM policy concurrently, invalidating the etag.
+ *    Retrying re-fetches the latest policy with a fresh etag and reapplies the desired bindings.
+ * 2. HTTP 400 (INVALID_ARGUMENT) with message like "Service account ... does not exist":
+ *    Occurs due to cross-region IAM eventual consistency lag immediately after service account creation.
+ *    Retrying absorbs this replication window.
+ *
+ * Fast-failed errors (returns false):
+ * - Always returns false for all non-4xx status codes (such as 5xx server errors or non-HTTP errors).
+ * - Returns false for all other 4xx status codes (e.g. 403, 404), as well as non-retryable 400 errors
+ *   (such as "Role roles/<name> does not exist.") which represent permanent configuration or permission
+ *   failures that will not resolve on retry.
+ */
 function isRetryableIamError(err: unknown): boolean {
   const status = getErrStatus(err);
   if (status === 409) {
@@ -99,18 +116,11 @@ export async function addServiceAccountToRoles(
       const projectPolicy = await getIamPolicy(projectId);
       projectPolicy.bindings = projectPolicy.bindings || [];
 
-      for (const roleName of roles) {
-        let binding = projectPolicy.bindings.find((b: Binding) => b.role === roleName);
-
-        // create a new binding if the role doesn't exist in the policy yet
-        if (!binding) {
-          binding = { role: roleName, members: [] };
-          projectPolicy.bindings.push(binding);
-        }
-        if (!binding.members.includes(newMemberName)) {
-          binding.members.push(newMemberName);
-        }
-      }
+      const requiredBindings: Binding[] = roles.map((role) => ({
+        role,
+        members: [newMemberName],
+      }));
+      mergeBindings(projectPolicy, requiredBindings);
 
       return await setIamPolicy(projectId, projectPolicy, "bindings");
     },

--- a/src/gcp/run.ts
+++ b/src/gcp/run.ts
@@ -3,7 +3,7 @@ import { FirebaseError } from "../error";
 import { runOrigin } from "../api";
 import * as proto from "./proto";
 import * as iam from "./iam";
-import { backoff } from "../throttler/throttler";
+import { backoff } from "../utils";
 import { logger } from "../logger";
 import { listEntries, LogEntry } from "./cloudlogging";
 

--- a/src/throttler/throttler.spec.ts
+++ b/src/throttler/throttler.spec.ts
@@ -3,7 +3,7 @@ import { expect } from "chai";
 
 import Queue from "./queue";
 import Stack from "./stack";
-import { Throttler, ThrottlerOptions, timeToWait } from "./throttler";
+import { Throttler, ThrottlerOptions } from "./throttler";
 import TaskError from "./errors/task-error";
 import TimeoutError from "./errors/timeout-error";
 import RetriesExhaustedError from "./errors/retries-exhausted-error";
@@ -406,30 +406,6 @@ describe("Throttler", () => {
   });
   describe("Stack", () => {
     throttlerTest(Stack);
-  });
-});
-
-describe("timeToWait", () => {
-  it("should wait the base delay on the first attempt", () => {
-    const retryCount = 0;
-    const delay = 100;
-    const maxDelay = 1000;
-    expect(timeToWait(retryCount, delay, maxDelay)).to.equal(delay);
-  });
-
-  it("should back off exponentially", () => {
-    const delay = 100;
-    const maxDelay = 1000;
-    expect(timeToWait(1, delay, maxDelay)).to.equal(delay * 2);
-    expect(timeToWait(2, delay, maxDelay)).to.equal(delay * 4);
-    expect(timeToWait(3, delay, maxDelay)).to.equal(delay * 8);
-  });
-
-  it("should not wait longer than maxDelay", () => {
-    const retryCount = 2;
-    const delay = 300;
-    const maxDelay = 400;
-    expect(timeToWait(retryCount, delay, maxDelay)).to.equal(maxDelay);
   });
 });
 

--- a/src/throttler/throttler.ts
+++ b/src/throttler/throttler.ts
@@ -1,24 +1,8 @@
 import { logger } from "../logger";
+import { backoff } from "../utils";
 import RetriesExhaustedError from "./errors/retries-exhausted-error";
 import TimeoutError from "./errors/timeout-error";
 import TaskError from "./errors/task-error";
-
-/**
- * Creates a promise to wait for the nth backoff.
- */
-export function backoff(retryNumber: number, delay: number, maxDelay: number): Promise<void> {
-  return new Promise((resolve: () => void) => {
-    setTimeout(resolve, timeToWait(retryNumber, delay, maxDelay));
-  });
-}
-
-// Exported for unit testing.
-/**
- * time to wait between backoffs
- */
-export function timeToWait(retryNumber: number, delay: number, maxDelay: number): number {
-  return Math.min(delay * Math.pow(2, retryNumber), maxDelay);
-}
 
 function DEFAULT_HANDLER<R>(task: any): Promise<R> {
   return (task as () => Promise<R>)();

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -6,7 +6,7 @@ import * as os from "os";
 import * as path from "path";
 
 import * as utils from "./utils";
-import { FirebaseError } from "./error";
+import { FirebaseError, getErrMsg } from "./error";
 
 describe("utils", () => {
   describe("consoleUrl", () => {
@@ -778,7 +778,7 @@ describe("utils", () => {
           retries: 3,
           delay: 1,
           maxDelay: 5,
-          retryPredicate: (err) => (err as Error).message === "transient error",
+          retryPredicate: (err) => getErrMsg(err) === "transient error",
         },
       );
       expect(result).to.equal("success");
@@ -796,7 +796,7 @@ describe("utils", () => {
           {
             delay: 1,
             maxDelay: 5,
-            retryPredicate: (err) => (err as Error).message === "other error",
+            retryPredicate: (err) => getErrMsg(err) === "other error",
           },
         ),
       ).to.be.rejectedWith("fatal error");

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -709,4 +709,117 @@ describe("utils", () => {
       expect(utils.stringDistance("flaw", "lawn")).to.equal(2);
     });
   });
+
+  describe("timeToWait", () => {
+    it("should wait the base delay on the first attempt", () => {
+      const retryCount = 0;
+      const delay = 100;
+      const maxDelay = 1000;
+      expect(utils.timeToWait(retryCount, delay, maxDelay)).to.equal(delay);
+    });
+
+    it("should back off exponentially", () => {
+      const delay = 100;
+      const maxDelay = 1000;
+      expect(utils.timeToWait(1, delay, maxDelay)).to.equal(delay * 2);
+      expect(utils.timeToWait(2, delay, maxDelay)).to.equal(delay * 4);
+      expect(utils.timeToWait(3, delay, maxDelay)).to.equal(delay * 8);
+    });
+
+    it("should not wait longer than maxDelay", () => {
+      const retryCount = 2;
+      const delay = 300;
+      const maxDelay = 400;
+      expect(utils.timeToWait(retryCount, delay, maxDelay)).to.equal(maxDelay);
+    });
+  });
+
+  describe("retryWithBackoff", () => {
+    it("should return result on first attempt if successful", async () => {
+      let attempts = 0;
+      const result = await utils.retryWithBackoff(
+        async () => {
+          attempts++;
+          return "success";
+        },
+        { retryPredicate: () => true },
+      );
+      expect(result).to.equal("success");
+      expect(attempts).to.equal(1);
+    });
+
+    it("should not retry if retries is omitted (default 0)", async () => {
+      let attempts = 0;
+      await expect(
+        utils.retryWithBackoff(
+          async () => {
+            attempts++;
+            throw new Error("transient error");
+          },
+          {
+            retryPredicate: () => true,
+          },
+        ),
+      ).to.be.rejectedWith("transient error");
+      expect(attempts).to.equal(1);
+    });
+
+    it("should retry and succeed when predicate matches", async () => {
+      let attempts = 0;
+      const result = await utils.retryWithBackoff(
+        async () => {
+          attempts++;
+          if (attempts < 3) {
+            throw new Error("transient error");
+          }
+          return "success";
+        },
+        {
+          retries: 3,
+          delay: 1,
+          maxDelay: 5,
+          retryPredicate: (err) => (err as Error).message === "transient error",
+        },
+      );
+      expect(result).to.equal("success");
+      expect(attempts).to.equal(3);
+    });
+
+    it("should fail fast if predicate returns false", async () => {
+      let attempts = 0;
+      await expect(
+        utils.retryWithBackoff(
+          async () => {
+            attempts++;
+            throw new Error("fatal error");
+          },
+          {
+            delay: 1,
+            maxDelay: 5,
+            retryPredicate: (err) => (err as Error).message === "other error",
+          },
+        ),
+      ).to.be.rejectedWith("fatal error");
+      expect(attempts).to.equal(1);
+    });
+
+    it("should throw after exhausting all retries", async () => {
+      let attempts = 0;
+      await expect(
+        utils.retryWithBackoff(
+          async () => {
+            attempts++;
+            throw new Error("persistent error");
+          },
+          {
+            retries: 3,
+            delay: 1,
+            maxDelay: 5,
+            retryPredicate: () => true,
+          },
+        ),
+      ).to.be.rejectedWith("persistent error");
+      expect(attempts).to.equal(4);
+    });
+  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -486,6 +486,59 @@ export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/** Calculates the exponential backoff delay in milliseconds. */
+export function timeToWait(retryNumber: number, delay: number, maxDelay: number): number {
+  return Math.min(delay * Math.pow(2, retryNumber), maxDelay);
+}
+
+/** Creates a promise to wait for the nth exponential backoff delay. */
+export function backoff(retryNumber: number, delay: number, maxDelay: number): Promise<void> {
+  return sleep(timeToWait(retryNumber, delay, maxDelay));
+}
+
+export interface RetryWithBackoffOptions {
+  /**
+   * Predicate determining whether an error is retryable. Required so callers
+   * explicitly define expected transient error conditions rather than blindly retrying fatal errors.
+   */
+  retryPredicate: (err: unknown) => boolean;
+  /** Maximum number of retry attempts before giving up. Default: 0 (matches Throttler). */
+  retries?: number;
+  /** Initial delay in milliseconds for the first retry backoff. Default: 200ms (matches Throttler). */
+  delay?: number;
+  /** Maximum delay cap in milliseconds for any single backoff sleep. Default: 60000ms (matches Throttler). */
+  maxDelay?: number;
+}
+
+/**
+ * Runs an asynchronous operation and retries it with exponential backoff when errors match `retryPredicate`.
+ *
+ * Timing defaults:
+ * - `delay`: 200ms (matches Throttler).
+ * - `maxDelay`: 60000ms (matches Throttler).
+ * - `retries`: 0 (matches Throttler).
+ */
+export async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  options: RetryWithBackoffOptions,
+): Promise<T> {
+  const retries = options.retries ?? 0;
+  const delay = options.delay ?? 200;
+  const maxDelay = options.maxDelay ?? 60000;
+
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fn();
+    } catch (err: unknown) {
+      if (attempt < retries && options.retryPredicate(err)) {
+        await backoff(attempt, delay, maxDelay);
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
 /**
  * Return a "destroy" function for a Node.js HTTP server. MUST be called on
  * server creation (e.g. right after `.listen`), BEFORE any connections.


### PR DESCRIPTION
### Description
Resource Manager setIamPolicy calls can fail transiently during service account provisioning due to replication lag (HTTP 400 INVALID_ARGUMENT with message "Service account ... does not exist.") and optimistic concurrency control conflicts (HTTP 409 ABORTED).

This change adds retryWithBackoff to src/utils.ts (migrating backoff calculation utilities from throttler to avoid circular dependencies) and wraps addServiceAccountToRoles in src/gcp/resourceManager.ts with exponential backoff retries. Retrying with backoff allows IAM replication to settle for newly created service accounts (resolving 400 errors) and re-fetches the policy to obtain a fresh etag (resolving 409 conflicts).

### Scenarios Tested
- Unit tests in src/utils.spec.ts verifying timeToWait and retryWithBackoff with successful runs, predicate retries, fast failures, and retry exhaustion.
- Unit tests in src/gcp/resourceManager.spec.ts verifying:
  - Retry on HTTP 400 "does not exist"
  - Retry on HTTP 409 conflict with etag refresh
  - Fast failure on HTTP 403 permission errors without retrying
  - Fast failure on HTTP 404 not found errors without retrying
- Existing throttler and run tests pass.
- npm run test
- Manual testing with repeated deploy and delete of kits verifying consistent success.

### Sample Commands
npx mocha src/utils.spec.ts src/throttler/throttler.spec.ts src/gcp/resourceManager.spec.ts
npm run test
firebase deploy --only functions:storage-resize-images
firebase functions:delete storage-resize-images
