### PR TITLE
fix(functions): prevent deadlock and stale source tokens during deployment retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Configured the SQL Connect (Data Connect) OneMCP proxy server in `ONEMCP_SERVERS` with a selection of remote tools.
 - Configured the `Mcp-Param-Region` HTTP header workaround in `OneMcpServer` for MCP routing support.
 - [fixed] Retry IAM policy updates on replication lag and concurrency conflicts.
+- [fixed] Prevent deadlock and stale source tokens during Cloud Functions deployment retries.

--- a/src/deploy/functions/release/fabricator.spec.ts
+++ b/src/deploy/functions/release/fabricator.spec.ts
@@ -654,7 +654,7 @@ describe("Fabricator", () => {
       } catch (err) {
         // do nothing, error is expected
       }
-      await expect(sc.getToken()).to.eventually.equal("magic token");
+      await expect(sc.withToken(async (t) => t)).to.eventually.equal("magic token");
     });
 
     it("deletes broken function and retries on cloud run quota exhaustion", async () => {
@@ -669,6 +669,34 @@ describe("Fabricator", () => {
 
       expect(gcfv2.createFunction).to.have.been.calledTwice;
       expect(gcfv2.deleteFunction).to.have.been.called;
+    });
+
+    it("retries createV2Function and succeeds when service account 404 occurs", async () => {
+      const queueExec = new executor.QueueExecutor({
+        retries: 5,
+        backoff: 1,
+        maxBackoff: 1,
+      });
+      const fabWithQueue = new fabricator.Fabricator({
+        ...ctorArgs,
+        functionExecutor: queueExec,
+      });
+
+      const saError: any = new Error(
+        "Service account sa@proj.iam.gserviceaccount.com was not found",
+      );
+      saError.status = 404;
+
+      gcfv2.createFunction.onFirstCall().rejects(saError);
+      gcfv2.createFunction.onSecondCall().resolves({ name: "op", done: false });
+      poller.pollOperation.resolves({ serviceConfig: { service: "service" } });
+      run.setInvokerCreate.resolves();
+
+      const ep = endpoint({ httpsTrigger: {} }, { platform: "gcfv2" });
+      const sc = new scraper.SourceTokenScraper();
+      await fabWithQueue.createV2Function(ep, sc);
+
+      expect(gcfv2.createFunction).to.have.been.calledTwice;
     });
 
     it("throws on set invoker failure", async () => {
@@ -1033,7 +1061,7 @@ describe("Fabricator", () => {
       } catch (err) {
         // do nothing, error is expected
       }
-      await expect(sc.getToken()).to.eventually.equal("magic token");
+      await expect(sc.withToken(async (t) => t)).to.eventually.equal("magic token");
     });
   });
 

--- a/src/deploy/functions/release/fabricator.spec.ts
+++ b/src/deploy/functions/release/fabricator.spec.ts
@@ -682,10 +682,10 @@ describe("Fabricator", () => {
         functionExecutor: queueExec,
       });
 
-      const saError: any = new Error(
+      const saError = new FirebaseError(
         "Service account sa@proj.iam.gserviceaccount.com was not found",
+        { status: 404 },
       );
-      saError.status = 404;
 
       gcfv2.createFunction.onFirstCall().rejects(saError);
       gcfv2.createFunction.onSecondCall().resolves({ name: "op", done: false });

--- a/src/deploy/functions/release/fabricator.ts
+++ b/src/deploy/functions/release/fabricator.ts
@@ -493,17 +493,22 @@ export class Fabricator {
     }
     const resultFunction = await this.functionExecutor
       .run(
-        async () => {
-          // try to get the source token right before deploying
-          apiFunction.sourceToken = await scraper.getToken();
-          const op: { name: string } = await gcf.createFunction(apiFunction);
-          return poller.pollOperation<gcf.CloudFunction>({
-            ...gcfV1PollerOptions,
-            pollerName: `create-${endpoint.codebase}-${endpoint.region}-${endpoint.id}`,
-            operationResourceName: op.name,
-            onPoll: scraper.poller,
-          });
-        },
+        () =>
+          scraper.withToken(async (token) => {
+            // Clear any token from a previous attempt so retries do not send a stale token.
+            // Explicitly delete instead of setting undefined so proto.fieldMasks() omits it.
+            delete apiFunction.sourceToken;
+            if (token) {
+              apiFunction.sourceToken = token;
+            }
+            const op: { name: string } = await gcf.createFunction(apiFunction);
+            return await poller.pollOperation<gcf.CloudFunction>({
+              ...gcfV1PollerOptions,
+              pollerName: `create-${endpoint.codebase}-${endpoint.region}-${endpoint.id}`,
+              operationResourceName: op.name,
+              onPoll: scraper.poller,
+            });
+          }),
         { retryPredicates: [isTransientError, isServiceAccount404] },
       )
       .catch(rethrowAs<gcf.CloudFunction>(endpoint, "create"));
@@ -624,24 +629,27 @@ export class Fabricator {
     while (!resultFunction) {
       resultFunction = await this.functionExecutor
         .run(
-          async () => {
-            if (experiments.isEnabled("functionsv2deployoptimizations")) {
-              apiFunction.buildConfig.sourceToken = await scraper.getToken();
-            }
-            const op: { name: string } = await gcfV2.createFunction(apiFunction);
-            return await poller.pollOperation<gcfV2.OutputCloudFunction>({
-              ...gcfV2PollerOptions,
-              pollerName: `create-${endpoint.codebase}-${endpoint.region}-${endpoint.id}`,
-              operationResourceName: op.name,
-              onPoll: scraper.poller,
-            });
-          },
+          () =>
+            scraper.withToken(async (token) => {
+              if (apiFunction.buildConfig) {
+                // Clear any token from a previous attempt so retries do not send a stale token.
+                // Explicitly delete instead of setting undefined so proto.fieldMasks() omits it.
+                delete apiFunction.buildConfig.sourceToken;
+                if (experiments.isEnabled("functionsv2deployoptimizations") && token) {
+                  apiFunction.buildConfig.sourceToken = token;
+                }
+              }
+              const op: { name: string } = await gcfV2.createFunction(apiFunction);
+              return await poller.pollOperation<gcfV2.OutputCloudFunction>({
+                ...gcfV2PollerOptions,
+                pollerName: `create-${endpoint.codebase}-${endpoint.region}-${endpoint.id}`,
+                operationResourceName: op.name,
+                onPoll: scraper.poller,
+              });
+            }),
           { retryPredicates: [isTransientError, isServiceAccount404] },
         )
         .catch(async (err: any) => {
-          // Abort waiting on source token so other concurrent calls don't get stuck
-          scraper.abort();
-
           // If the createFunction call returns RPC error code RESOURCE_EXHAUSTED (8),
           // we have exhausted the underlying Cloud Run API quota. To retry, we need to
           // first delete the GCF function resource, then call createFunction again.
@@ -726,16 +734,25 @@ export class Fabricator {
     const apiFunction = gcf.functionFromEndpoint(endpoint, sourceUrl);
 
     const resultFunction = await this.functionExecutor
-      .run(async () => {
-        apiFunction.sourceToken = await scraper.getToken();
-        const op: { name: string } = await gcf.updateFunction(apiFunction);
-        return await poller.pollOperation<gcf.CloudFunction>({
-          ...gcfV1PollerOptions,
-          pollerName: `update-${endpoint.codebase}-${endpoint.region}-${endpoint.id}`,
-          operationResourceName: op.name,
-          onPoll: scraper.poller,
-        });
-      })
+      .run(
+        () =>
+          scraper.withToken(async (token) => {
+            // Clear any token from a previous attempt so retries do not send a stale token.
+            // Explicitly delete instead of setting undefined so proto.fieldMasks() omits it.
+            delete apiFunction.sourceToken;
+            if (token) {
+              apiFunction.sourceToken = token;
+            }
+            const op: { name: string } = await gcf.updateFunction(apiFunction);
+            return await poller.pollOperation<gcf.CloudFunction>({
+              ...gcfV1PollerOptions,
+              pollerName: `update-${endpoint.codebase}-${endpoint.region}-${endpoint.id}`,
+              operationResourceName: op.name,
+              onPoll: scraper.poller,
+            });
+          }),
+        { retryPredicates: [isTransientError, isServiceAccount404] },
+      )
       .catch(rethrowAs<gcf.CloudFunction>(endpoint, "update"));
 
     endpoint.uri = resultFunction?.httpsTrigger?.url;
@@ -775,22 +792,27 @@ export class Fabricator {
 
     const resultFunction = await this.functionExecutor
       .run(
-        async () => {
-          if (experiments.isEnabled("functionsv2deployoptimizations")) {
-            apiFunction.buildConfig.sourceToken = await scraper.getToken();
-          }
-          const op: { name: string } = await gcfV2.updateFunction(apiFunction);
-          return await poller.pollOperation<gcfV2.OutputCloudFunction>({
-            ...gcfV2PollerOptions,
-            pollerName: `update-${endpoint.codebase}-${endpoint.region}-${endpoint.id}`,
-            operationResourceName: op.name,
-            onPoll: scraper.poller,
-          });
-        },
+        () =>
+          scraper.withToken(async (token) => {
+            if (apiFunction.buildConfig) {
+              // Clear any token from a previous attempt so retries do not send a stale token.
+              // Explicitly delete instead of setting undefined so proto.fieldMasks() omits it.
+              delete apiFunction.buildConfig.sourceToken;
+              if (experiments.isEnabled("functionsv2deployoptimizations") && token) {
+                apiFunction.buildConfig.sourceToken = token;
+              }
+            }
+            const op: { name: string } = await gcfV2.updateFunction(apiFunction);
+            return await poller.pollOperation<gcfV2.OutputCloudFunction>({
+              ...gcfV2PollerOptions,
+              pollerName: `update-${endpoint.codebase}-${endpoint.region}-${endpoint.id}`,
+              operationResourceName: op.name,
+              onPoll: scraper.poller,
+            });
+          }),
         { retryPredicates: [isTransientError, isCloudRunResourceExhausted, isServiceAccount404] },
       )
       .catch((err: any) => {
-        scraper.abort();
         logger.error((err as Error).message);
         throw new reporter.DeploymentError(endpoint, "update", err);
       });

--- a/src/deploy/functions/release/sourceTokenScraper.spec.ts
+++ b/src/deploy/functions/release/sourceTokenScraper.spec.ts
@@ -5,22 +5,22 @@ import { SourceTokenScraper } from "./sourceTokenScraper";
 describe("SourceTokenScraper", () => {
   it("immediately provides the first result", async () => {
     const scraper = new SourceTokenScraper();
-    await expect(scraper.getToken()).to.eventually.be.undefined;
+    await expect(scraper.withToken(async (t) => t)).to.eventually.be.undefined;
   });
 
   it("provides results after the first operation completes", async () => {
     const scraper = new SourceTokenScraper();
     // First result comes right away;
-    await expect(scraper.getToken()).to.eventually.be.undefined;
+    await expect(scraper.withToken(async (t) => t)).to.eventually.be.undefined;
 
     let gotResult = false;
     const timeout = new Promise((resolve, reject) => {
       setTimeout(() => reject(new Error("Timeout")), 10);
     });
-    const getResult = (async () => {
-      await scraper.getToken();
+    const getResult = scraper.withToken(async (t) => {
       gotResult = true;
-    })();
+      return t;
+    });
     await expect(Promise.race([getResult, timeout])).to.be.rejectedWith("Timeout");
     expect(gotResult).to.be.false;
 
@@ -31,7 +31,7 @@ describe("SourceTokenScraper", () => {
   it("provides tokens from an operation", async () => {
     const scraper = new SourceTokenScraper();
     // First result comes right away
-    await expect(scraper.getToken()).to.eventually.be.undefined;
+    await expect(scraper.withToken(async (t) => t)).to.eventually.be.undefined;
 
     scraper.poller({
       metadata: {
@@ -39,45 +39,49 @@ describe("SourceTokenScraper", () => {
         target: "projects/p/locations/l/functions/f",
       },
     });
-    await expect(scraper.getToken()).to.eventually.equal("magic token");
+    await expect(scraper.withToken(async (t) => t)).to.eventually.equal("magic token");
   });
 
   it("refreshes token after timer expires", async () => {
     const scraper = new SourceTokenScraper(10);
-    await expect(scraper.getToken()).to.eventually.be.undefined;
+    await expect(scraper.withToken(async (t) => t)).to.eventually.be.undefined;
     scraper.poller({
       metadata: {
         sourceToken: "magic token",
         target: "projects/p/locations/l/functions/f",
       },
     });
-    await expect(scraper.getToken()).to.eventually.equal("magic token");
+    await expect(scraper.withToken(async (t) => t)).to.eventually.equal("magic token");
     const timeout = (duration: number): Promise<void> => {
       return new Promise<void>((resolve) => setTimeout(resolve, duration));
     };
     await timeout(50);
-    await expect(scraper.getToken()).to.eventually.be.undefined;
+    await expect(scraper.withToken(async (t) => t)).to.eventually.be.undefined;
     scraper.poller({
       metadata: {
         sourceToken: "magic token #2",
         target: "projects/p/locations/l/functions/f",
       },
     });
-    await expect(scraper.getToken()).to.eventually.equal("magic token #2");
+    await expect(scraper.withToken(async (t) => t)).to.eventually.equal("magic token #2");
   });
 
   it("tries to fetch a new source token upon abort", async () => {
     const scraper = new SourceTokenScraper();
-    await expect(scraper.getToken()).to.eventually.be.undefined;
-    scraper.abort();
-    await expect(scraper.getToken()).to.eventually.be.undefined;
+    await expect(
+      scraper.withToken(async () => {
+        throw new Error("Failed deploy");
+      }),
+    ).to.be.rejectedWith("Failed deploy");
+
+    await expect(scraper.withToken(async (t) => t)).to.eventually.be.undefined;
     scraper.poller({
       metadata: {
         sourceToken: "magic token",
         target: "projects/p/locations/l/functions/f",
       },
     });
-    await expect(scraper.getToken()).to.eventually.equal("magic token");
+    await expect(scraper.withToken(async (t) => t)).to.eventually.equal("magic token");
   });
 
   it("concurrent requests for source token", async () => {
@@ -85,7 +89,7 @@ describe("SourceTokenScraper", () => {
 
     const promises = [];
     for (let i = 0; i < 3; i++) {
-      promises.push(scraper.getToken());
+      promises.push(scraper.withToken(async (t) => t));
     }
     scraper.poller({
       metadata: {
@@ -103,5 +107,77 @@ describe("SourceTokenScraper", () => {
     }
     expect(tokens.includes(undefined)).to.be.true;
     expect(successes).to.equal(2);
+  });
+
+  it("unblocks waiting callers on abort and allows subsequent fetches", async () => {
+    const scraper = new SourceTokenScraper();
+
+    // First caller starts fetching and will fail asynchronously
+    let failFirst!: (err: Error) => void;
+    let firstOp!: Promise<unknown>;
+    const firstOpStarted = new Promise<void>((ready) => {
+      firstOp = scraper.withToken(
+        () =>
+          new Promise((_, reject) => {
+            failFirst = reject;
+            ready();
+          }),
+      );
+    });
+    await firstOpStarted;
+
+    // Two callers start waiting for the token
+    const waiting1 = scraper.withToken(async (t) => t);
+    const waiting2 = scraper.withToken(async (t) => t);
+
+    // Fail the ongoing operation, triggering abort
+    failFirst(new Error("Deploy failed"));
+    await expect(firstOp).to.be.rejectedWith("Deploy failed");
+
+    // Both waiting callers should receive undefined and not hang
+    const [res1, res2] = await Promise.all([waiting1, waiting2]);
+    expect(res1).to.be.undefined;
+    expect(res2).to.be.undefined;
+
+    // A subsequent caller (or retrying task) should be able to initiate a new fetch
+    const retryToken = await scraper.withToken(async (t) => t);
+    expect(retryToken).to.be.undefined;
+
+    // And subsequent waiters get the token once poller completes
+    const waiterAfterRetry = scraper.withToken(async (t) => t);
+    scraper.poller({
+      metadata: {
+        sourceToken: "new token",
+        target: "projects/p/locations/l/functions/f",
+      },
+    });
+    expect(await waiterAfterRetry).to.equal("new token");
+  });
+
+  it("withToken returns operation result on success", async () => {
+    const scraper = new SourceTokenScraper();
+    const result = await scraper.withToken(async (token) => {
+      expect(token).to.be.undefined;
+      return "success";
+    });
+    expect(result).to.equal("success");
+  });
+
+  it("withToken automatically aborts when operation throws", async () => {
+    const scraper = new SourceTokenScraper();
+
+    // First caller starts withToken and fails
+    const failedOp = scraper.withToken(async () => {
+      throw new Error("Deploy failed");
+    });
+
+    await expect(failedOp).to.be.rejectedWith("Deploy failed");
+
+    // A subsequent caller should be able to initiate a new fetch without deadlock
+    const nextResult = await scraper.withToken(async (token) => {
+      expect(token).to.be.undefined;
+      return "recovered";
+    });
+    expect(nextResult).to.equal("recovered");
   });
 });

--- a/src/deploy/functions/release/sourceTokenScraper.ts
+++ b/src/deploy/functions/release/sourceTokenScraper.ts
@@ -26,18 +26,36 @@ export class SourceTokenScraper {
     this.fetchState = "NONE";
   }
 
-  abort(): void {
-    this.resolve({ aborted: true });
+  /**
+   * Runs an operation with a source token.
+   * If the operation throws, automatically aborts the token fetch to prevent deadlocks.
+   */
+  async withToken<T>(fn: (token: string | undefined) => Promise<T>): Promise<T> {
+    const token = await this.getToken();
+    try {
+      return await fn(token);
+    } catch (err) {
+      this.abort();
+      throw err;
+    }
   }
 
-  async getToken(): Promise<string | undefined> {
+  private abort(): void {
+    if (this.fetchState === "FETCHING") {
+      this.fetchState = "NONE";
+      const resolve = this.resolve;
+      this.promise = new Promise((r) => (this.resolve = r));
+      resolve({ aborted: true });
+    }
+  }
+
+  private async getToken(): Promise<string | undefined> {
     if (this.fetchState === "NONE") {
       this.fetchState = "FETCHING";
       return undefined;
     } else if (this.fetchState === "FETCHING") {
       const tokenResult = await this.promise;
       if (tokenResult.aborted) {
-        this.promise = new Promise((resolve) => (this.resolve = resolve));
         return undefined;
       }
       return tokenResult.token;
@@ -54,7 +72,7 @@ export class SourceTokenScraper {
     }
   }
 
-  isTokenExpired(): boolean {
+  private isTokenExpired(): boolean {
     if (this.expiry === undefined) {
       throw new FirebaseError(
         "Your deployment is checking the expiration of a source token that has not yet been polled. " +


### PR DESCRIPTION
### Description
During Cloud Functions deployments, the fabricator shares a single build across regional function deployments using source tokens and retries failed tasks via QueueExecutor. When an initial deployment task fails transiently (e.g. service account replication lag or quota limits), the retry pipeline previously encountered deadlocks and invalid API requests: in-flight callers waiting on the build token remained blocked on abort, and retried function objects could retain stale tokens or leak undefined properties into GCP update masks.

This change encapsulates source token acquisition in SourceTokenScraper.withToken, ensuring token lifecycle and error handling are managed atomically while keeping internal coordination methods private. It updates abort() to cleanly unblock all concurrent waiters when an in-flight build fails so subsequent retries can initiate a fresh build without hanging. In Fabricator, v1 and v2 deployment operations now run via withToken, safely clearing any stale token from previous attempts and setting it only when a valid build token is present.

This is a stacked change on top of #11043. Implementation wise they are independent, but they are both required to fix flaky kit deploys and best manually tested together if you're looking for a result of not flaky deployments.

### Scenarios Tested
- Unit tests in src/deploy/functions/release/sourceTokenScraper.spec.ts verifying:
  - Immediate token provision and retrieval after poller completion
  - Unblocking all concurrent waiters on abort without hanging
  - Initiating fresh fetches after abort
  - Token refresh after expiration
  - withToken execution on success and automatic abort on error
- Unit tests in src/deploy/functions/release/fabricator.spec.ts verifying:
  - QueueExecutor retrying createV2Function and recovering from service account 404 errors
  - Token retrieval on abort for v2 create and update operations
  - Existing v1 and v2 deployment and lifecycle tests pass
- npm run test
- Manual testing deploying and deleting functions with kits.

### Sample Commands
npm run test
firebase deploy --only functions:storage-resize-images
firebase functions:delete storage-resize-images
