### PR TITLE
fix(functions): don't crash setting the enqueuer on a queue with no IAM policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Updated the Firebase SQL Connect local toolkit to v3.4.19, which includes the following changes:
   - [fixed] Bug fixes and performance improvements for the PostgreSQL emulator.
 - [fixed] Clean up managed service accounts when all functions in a codebase are deleted.
+- [fixed] Fixed a crash when redeploying a task queue function whose queue has no IAM policy set.

--- a/src/gcp/cloudtasks.spec.ts
+++ b/src/gcp/cloudtasks.spec.ts
@@ -251,7 +251,8 @@ describe("CloudTasks", () => {
 
     it("can insert a binding into a policy that has never been set", async () => {
       // A queue with no IAM policy yet comes back without a `bindings` field at all.
-      ct.getIamPolicy.resolves({ etag: "", version: 3 } as unknown as iam.Policy);
+      const noBindings: Partial<iam.Policy> = { etag: "", version: 3 };
+      ct.getIamPolicy.resolves(noBindings as iam.Policy);
 
       await cloudtasks.setEnqueuer(NAME, ["public"]);
       expect(ct.getIamPolicy).to.have.been.called;

--- a/src/gcp/cloudtasks.spec.ts
+++ b/src/gcp/cloudtasks.spec.ts
@@ -249,6 +249,19 @@ describe("CloudTasks", () => {
       });
     });
 
+    it("can insert a binding into a policy that has never been set", async () => {
+      // A queue with no IAM policy yet comes back without a `bindings` field at all.
+      ct.getIamPolicy.resolves({ etag: "", version: 3 } as unknown as iam.Policy);
+
+      await cloudtasks.setEnqueuer(NAME, ["public"]);
+      expect(ct.getIamPolicy).to.have.been.called;
+      expect(ct.setIamPolicy).to.have.been.calledWith(NAME, {
+        bindings: [PUBLIC_ENQUEUER_BINDING],
+        etag: "",
+        version: 3,
+      });
+    });
+
     it("can resolve conflicts", async () => {
       ct.getIamPolicy.onCall(0).resolves({
         bindings: [ADMIN_BINDING],

--- a/src/gcp/cloudtasks.ts
+++ b/src/gcp/cloudtasks.ts
@@ -169,6 +169,16 @@ export async function getIamPolicy(name: string): Promise<iam.Policy> {
 
 const ENQUEUER_ROLE = "roles/cloudtasks.enqueuer";
 
+/**
+ * A queue whose IAM policy has never been set comes back from the API with no
+ * `bindings` field at all, even though iam.Policy declares it required. Fill it in
+ * on read so callers can treat it as the empty array it represents. `run.ts` already
+ * applies the same guard to Cloud Run service policies.
+ */
+function withBindings(policy: iam.Policy): iam.Policy {
+  return { ...policy, bindings: policy.bindings ?? [] };
+}
+
 /** Ensures that the invoker policy is set for a given queue. */
 export async function setEnqueuer(
   name: string,
@@ -183,7 +193,7 @@ export async function setEnqueuer(
       version: 3,
     };
   } else {
-    existing = await (module.exports.getIamPolicy as typeof getIamPolicy)(name);
+    existing = withBindings(await (module.exports.getIamPolicy as typeof getIamPolicy)(name));
   }
 
   const [, project] = name.split("/");
@@ -209,7 +219,7 @@ export async function setEnqueuer(
     } catch (err: any) {
       // Re-fetch on conflict
       if (err?.context?.response?.statusCode === 429) {
-        existing = await (module.exports.getIamPolicy as typeof getIamPolicy)(name);
+        existing = withBindings(await (module.exports.getIamPolicy as typeof getIamPolicy)(name));
         continue;
       }
       throw err;

--- a/src/gcp/cloudtasks.ts
+++ b/src/gcp/cloudtasks.ts
@@ -169,16 +169,6 @@ export async function getIamPolicy(name: string): Promise<iam.Policy> {
 
 const ENQUEUER_ROLE = "roles/cloudtasks.enqueuer";
 
-/**
- * A queue whose IAM policy has never been set comes back from the API with no
- * `bindings` field at all, even though iam.Policy declares it required. Fill it in
- * on read so callers can treat it as the empty array it represents. `run.ts` already
- * applies the same guard to Cloud Run service policies.
- */
-function withBindings(policy: iam.Policy): iam.Policy {
-  return { ...policy, bindings: policy.bindings ?? [] };
-}
-
 /** Ensures that the invoker policy is set for a given queue. */
 export async function setEnqueuer(
   name: string,
@@ -193,7 +183,9 @@ export async function setEnqueuer(
       version: 3,
     };
   } else {
-    existing = withBindings(await (module.exports.getIamPolicy as typeof getIamPolicy)(name));
+    existing = await (module.exports.getIamPolicy as typeof getIamPolicy)(name);
+    // A queue whose IAM policy has never been set comes back without `bindings`.
+    existing.bindings ??= [];
   }
 
   const [, project] = name.split("/");
@@ -219,7 +211,8 @@ export async function setEnqueuer(
     } catch (err: any) {
       // Re-fetch on conflict
       if (err?.context?.response?.statusCode === 429) {
-        existing = withBindings(await (module.exports.getIamPolicy as typeof getIamPolicy)(name));
+        existing = await (module.exports.getIamPolicy as typeof getIamPolicy)(name);
+        existing.bindings ??= [];
         continue;
       }
       throw err;


### PR DESCRIPTION
### Description

`cloudtasks.setEnqueuer` filters the queue's existing IAM policy without guarding `bindings`:

```ts
const policy: iam.Policy = {
  bindings: existing.bindings.filter((binding) => binding.role !== ENQUEUER_ROLE),
```

A queue whose IAM policy has never been set comes back from the API with no `bindings` field at all — `iam.Policy` declares it required, so nothing catches this at compile time:

```
$ gcloud tasks queues get-iam-policy myQueue --location=us-central1
etag: ACAB
```

so the filter throws `TypeError: Cannot read properties of undefined (reading 'filter')`.

**How it's reached.** A task queue function deployed *without* an `invoker` option never calls `setEnqueuer` at all — `upsertTaskQueue` guards on `if (endpoint.taskQueueTrigger.invoker)` — so the queue is created and its policy left unset. Adding `invoker` later and redeploying takes the update path, which fetches the real (empty) policy and throws. The create path already sidesteps this by passing `assumeEmpty`, which is why a first deploy *with* `invoker` works fine.

What the user sees is misleading — the crash is swallowed into an IAM-permissions message that points at the wrong thing:

```
Cannot read properties of undefined (reading 'filter')
⚠  functions: Deploys failed. Skipping deletes.

Unable to set the invoker for the IAM policy on the following functions:
	deliverWorkflowFailureDigestProd(us-central1)

Some common causes of this:
- You may not have the roles/functions.admin IAM role. [...]
```

The account had `roles/owner`. Recovering takes an out-of-band `gcloud tasks queues add-iam-policy-binding` to give the policy any binding at all, after which deploys succeed — which is what pointed at the empty policy as the trigger.

This mirrors what `run.ts` already does for Cloud Run service policies (`currentPolicy.bindings?.find`, `(currentPolicy.bindings || []).filter`), so the fix normalizes on read in the same spirit. The same unguarded `policy.bindings` pattern exists in `iam.ts`, `resourceManager.ts`, `extensions/diagnose.ts` and `deploy/extensions/v2FunctionHelper.ts`, but those operate on project and extension policies, which in practice always have at least one binding — left alone to keep this fix narrow.

### Scenarios Tested

- New unit test `can insert a binding into a policy that has never been set` in `src/gcp/cloudtasks.spec.ts`. Verified it fails on `main` with exactly the production error, and passes with the fix:

  ```
  1) CloudTasks setEnqueuer can insert a binding into a policy that has never been set:
     TypeError: Cannot read properties of undefined (reading 'filter')
      at Object.setEnqueuer (src/gcp/cloudtasks.ts:111:41)
  ```

- Full `src/gcp/cloudtasks.spec.ts` suite: 13 passing.
- `prettier --check` clean; `eslint` on the changed files reports 0 errors and the same 12 pre-existing warnings as `main`; `tsc --noEmit` clean.
- Reproduced end to end against a real project: a task queue function first deployed without `invoker`, then redeployed with it, fails as above; seeding the queue policy with a single binding makes the same deploy succeed.

### Sample Commands

No command or flag changes. Affects `firebase deploy --only functions:<taskQueueFunction>`.
