### PR TITLE
fix(functions): retry on HTTP 400 service account propagation errors during function creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 - Configured the `Mcp-Param-Region` HTTP header workaround in `OneMcpServer` for MCP routing support.
 - [fixed] Retry IAM policy updates on replication lag and concurrency conflicts.
 - [fixed] Prevent deadlock and stale source tokens during Cloud Functions deployment retries.
+- [fixed] Retry Cloud Functions creation on HTTP 400 service account propagation errors.

--- a/src/deploy/functions/release/executor.spec.ts
+++ b/src/deploy/functions/release/executor.spec.ts
@@ -122,7 +122,7 @@ describe("Executor", () => {
       expect(executor.isServiceAccount404(err3)).to.be.true;
     });
 
-    it("does not match non-404 errors or non-service-account 404 errors", () => {
+    it("does not match non-404/400 errors or non-service-account errors", () => {
       const err1: any = new Error("Service account missing");
       err1.status = 500;
       expect(executor.isServiceAccount404(err1)).to.be.false;
@@ -130,6 +130,36 @@ describe("Executor", () => {
       const err2: any = new Error("Function region us-central1 not found");
       err2.status = 404;
       expect(executor.isServiceAccount404(err2)).to.be.false;
+
+      const err3: any = new Error("Invalid function name: my-func");
+      err3.status = 400;
+      expect(executor.isServiceAccount404(err3)).to.be.false;
+    });
+
+    it("matches 400 errors caused by service account propagation delays", () => {
+      const err1: any = new Error(
+        "Validation failed for trigger projects/p/locations/l/triggers/t: The request was invalid: invalid service account firebase-fn-5768298711@p.iam.gserviceaccount.com provided",
+      );
+      err1.status = 400;
+      expect(executor.isServiceAccount404(err1)).to.be.true;
+
+      const err2: any = new Error(
+        "The request was invalid: invalid service account firebase-fn-123@p.iam.gserviceaccount.com in project 12345 provided",
+      );
+      err2.status = 400;
+      expect(executor.isServiceAccount404(err2)).to.be.true;
+
+      const err3: any = new Error(
+        "The request was invalid: invalid service account custom-sa@p.iam.gserviceaccount.com provided",
+      );
+      err3.status = 400;
+      expect(executor.isServiceAccount404(err3)).to.be.false;
+
+      const err4: any = new Error(
+        "Service account firebase-fn-123@p.iam.gserviceaccount.com has permission denied",
+      );
+      err4.status = 400;
+      expect(executor.isServiceAccount404(err4)).to.be.false;
     });
 
     it("inspects all error message sources when err.message is generic", () => {

--- a/src/deploy/functions/release/executor.spec.ts
+++ b/src/deploy/functions/release/executor.spec.ts
@@ -75,7 +75,7 @@ describe("Executor", () => {
       };
 
       const result = await exec.run(handler, {
-        retryPredicates: [executor.isTransientError, executor.isServiceAccount404],
+        retryPredicates: [executor.isTransientError, executor.isServiceAccountPropagationError],
       });
       expect(result).to.equal("success");
       expect(attempts).to.equal(2);
@@ -87,7 +87,7 @@ describe("Executor", () => {
         retries: 5,
         maxBackoff: 1,
         backoff: 1,
-        defaultRetryPredicates: [executor.isServiceAccount404],
+        defaultRetryPredicates: [executor.isServiceAccountPropagationError],
       });
 
       const handler = (): Promise<string> => {
@@ -106,32 +106,32 @@ describe("Executor", () => {
     });
   });
 
-  describe("isServiceAccount404", () => {
+  describe("isServiceAccountPropagationError", () => {
     it("matches 404 errors containing service account references", () => {
       const err1: any = new Error("Service account proj@iam.gserviceaccount.com does not exist");
       err1.status = 404;
-      expect(executor.isServiceAccount404(err1)).to.be.true;
+      expect(executor.isServiceAccountPropagationError(err1)).to.be.true;
 
       const err2: any = new Error("Resource 'serviceaccount' not found");
       err2.code = 404;
-      expect(executor.isServiceAccount404(err2)).to.be.true;
+      expect(executor.isServiceAccountPropagationError(err2)).to.be.true;
 
       const err3: any = {
         status: 404,
         context: { body: { error: { message: "service account missing" } } },
       };
-      expect(executor.isServiceAccount404(err3)).to.be.true;
+      expect(executor.isServiceAccountPropagationError(err3)).to.be.true;
     });
 
     it("does not match non-404/400 errors or non-service-account errors", () => {
       const err1 = new FirebaseError("Service account missing", { status: 500 });
-      expect(executor.isServiceAccount404(err1)).to.be.false;
+      expect(executor.isServiceAccountPropagationError(err1)).to.be.false;
 
       const err2 = new FirebaseError("Function region us-central1 not found", { status: 404 });
-      expect(executor.isServiceAccount404(err2)).to.be.false;
+      expect(executor.isServiceAccountPropagationError(err2)).to.be.false;
 
       const err3 = new FirebaseError("Invalid function name: my-func", { status: 400 });
-      expect(executor.isServiceAccount404(err3)).to.be.false;
+      expect(executor.isServiceAccountPropagationError(err3)).to.be.false;
     });
 
     it("matches 400 errors caused by service account propagation delays", () => {
@@ -139,25 +139,25 @@ describe("Executor", () => {
         "Validation failed for trigger projects/p/locations/l/triggers/t: The request was invalid: invalid service account firebase-fn-5768298711@p.iam.gserviceaccount.com provided",
         { status: 400 },
       );
-      expect(executor.isServiceAccount404(err1)).to.be.true;
+      expect(executor.isServiceAccountPropagationError(err1)).to.be.true;
 
       const err2 = new FirebaseError(
         "The request was invalid: invalid service account firebase-fn-123@p.iam.gserviceaccount.com in project 12345 provided",
         { status: 400 },
       );
-      expect(executor.isServiceAccount404(err2)).to.be.true;
+      expect(executor.isServiceAccountPropagationError(err2)).to.be.true;
 
       const err3 = new FirebaseError(
         "The request was invalid: invalid service account custom-sa@p.iam.gserviceaccount.com provided",
         { status: 400 },
       );
-      expect(executor.isServiceAccount404(err3)).to.be.false;
+      expect(executor.isServiceAccountPropagationError(err3)).to.be.false;
 
       const err4 = new FirebaseError(
         "Service account firebase-fn-123@p.iam.gserviceaccount.com has permission denied",
         { status: 400 },
       );
-      expect(executor.isServiceAccount404(err4)).to.be.false;
+      expect(executor.isServiceAccountPropagationError(err4)).to.be.false;
     });
 
     it("inspects all error message sources when err.message is generic", () => {
@@ -170,7 +170,7 @@ describe("Executor", () => {
           },
         },
       };
-      expect(executor.isServiceAccount404(genericErr)).to.be.true;
+      expect(executor.isServiceAccountPropagationError(genericErr)).to.be.true;
     });
 
     it("safely handles circular error objects without throwing", () => {
@@ -179,7 +179,7 @@ describe("Executor", () => {
       );
       circularErr.status = 404;
       circularErr.self = circularErr; // Circular reference
-      expect(executor.isServiceAccount404(circularErr)).to.be.true;
+      expect(executor.isServiceAccountPropagationError(circularErr)).to.be.true;
     });
   });
 

--- a/src/deploy/functions/release/executor.spec.ts
+++ b/src/deploy/functions/release/executor.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 
+import { FirebaseError } from "../../../error";
 import * as executor from "./executor";
 
 describe("Executor", () => {
@@ -123,42 +124,39 @@ describe("Executor", () => {
     });
 
     it("does not match non-404/400 errors or non-service-account errors", () => {
-      const err1: any = new Error("Service account missing");
-      err1.status = 500;
+      const err1 = new FirebaseError("Service account missing", { status: 500 });
       expect(executor.isServiceAccount404(err1)).to.be.false;
 
-      const err2: any = new Error("Function region us-central1 not found");
-      err2.status = 404;
+      const err2 = new FirebaseError("Function region us-central1 not found", { status: 404 });
       expect(executor.isServiceAccount404(err2)).to.be.false;
 
-      const err3: any = new Error("Invalid function name: my-func");
-      err3.status = 400;
+      const err3 = new FirebaseError("Invalid function name: my-func", { status: 400 });
       expect(executor.isServiceAccount404(err3)).to.be.false;
     });
 
     it("matches 400 errors caused by service account propagation delays", () => {
-      const err1: any = new Error(
+      const err1 = new FirebaseError(
         "Validation failed for trigger projects/p/locations/l/triggers/t: The request was invalid: invalid service account firebase-fn-5768298711@p.iam.gserviceaccount.com provided",
+        { status: 400 },
       );
-      err1.status = 400;
       expect(executor.isServiceAccount404(err1)).to.be.true;
 
-      const err2: any = new Error(
+      const err2 = new FirebaseError(
         "The request was invalid: invalid service account firebase-fn-123@p.iam.gserviceaccount.com in project 12345 provided",
+        { status: 400 },
       );
-      err2.status = 400;
       expect(executor.isServiceAccount404(err2)).to.be.true;
 
-      const err3: any = new Error(
+      const err3 = new FirebaseError(
         "The request was invalid: invalid service account custom-sa@p.iam.gserviceaccount.com provided",
+        { status: 400 },
       );
-      err3.status = 400;
       expect(executor.isServiceAccount404(err3)).to.be.false;
 
-      const err4: any = new Error(
+      const err4 = new FirebaseError(
         "Service account firebase-fn-123@p.iam.gserviceaccount.com has permission denied",
+        { status: 400 },
       );
-      err4.status = 400;
       expect(executor.isServiceAccount404(err4)).to.be.false;
     });
 

--- a/src/deploy/functions/release/executor.ts
+++ b/src/deploy/functions/release/executor.ts
@@ -32,7 +32,7 @@ export const isServiceUnavailable: RetryPredicate = (err: any): boolean =>
 export const isTransientError: RetryPredicate = (err: any): boolean =>
   isQuotaExhaustion(err) || isConflict(err) || isServiceUnavailable(err);
 
-export const isServiceAccount404: RetryPredicate = (err: any): boolean => {
+export const isServiceAccountPropagationError: RetryPredicate = (err: any): boolean => {
   const code = parseErrorCode(err);
   // Newly created service accounts take time to propagate across IAM systems.
   // When downstream services (such as Eventarc trigger creation) validate the request,

--- a/src/deploy/functions/release/executor.ts
+++ b/src/deploy/functions/release/executor.ts
@@ -33,7 +33,17 @@ export const isTransientError: RetryPredicate = (err: any): boolean =>
   isQuotaExhaustion(err) || isConflict(err) || isServiceUnavailable(err);
 
 export const isServiceAccount404: RetryPredicate = (err: any): boolean => {
-  if (parseErrorCode(err) !== 404) {
+  const code = parseErrorCode(err);
+  // Newly created service accounts take time to propagate across IAM systems.
+  // When downstream services (such as Eventarc trigger creation) validate the request,
+  // an unpropagated service account fails input validation and is reported as HTTP 400
+  // (INVALID_ARGUMENT: "The request was invalid: invalid service account ... provided")
+  // rather than HTTP 404 (which is reserved for missing API URL resources).
+  //
+  // To avoid false positives on user typos with custom service accounts, HTTP 400
+  // retries are restricted to declarative security service accounts (firebase-fn-[0-9]+@),
+  // which are provisioned dynamically on the fly during deployment.
+  if (code !== 404 && code !== 400) {
     return false;
   }
   let message = "";
@@ -42,6 +52,7 @@ export const isServiceAccount404: RetryPredicate = (err: any): boolean => {
       err?.message,
       err?.original?.message,
       err?.context?.body?.error?.message,
+      err?.original?.context?.body?.error?.message,
       String(err),
     ]
       .filter(Boolean)
@@ -50,12 +61,21 @@ export const isServiceAccount404: RetryPredicate = (err: any): boolean => {
   } catch {
     message = String(err).toLowerCase();
   }
-  return (
+  const hasSa =
     message.includes("serviceaccount") ||
     message.includes("service account") ||
     /\b[a-z0-9._%+-]+@[a-z0-9.-]+\.gserviceaccount\.com\b/i.test(message) ||
-    /\bgserviceaccount\.com\b/i.test(message)
-  );
+    /\bgserviceaccount\.com\b/i.test(message);
+
+  if (!hasSa) {
+    return false;
+  }
+
+  if (code === 404) {
+    return true;
+  }
+
+  return message.includes("invalid service account") && /\bfirebase-fn-[0-9]+@/i.test(message);
 };
 
 export const isCloudRunResourceExhausted: RetryPredicate = (err: any): boolean =>

--- a/src/deploy/functions/release/executor.ts
+++ b/src/deploy/functions/release/executor.ts
@@ -61,11 +61,7 @@ export const isServiceAccount404: RetryPredicate = (err: any): boolean => {
   } catch {
     message = String(err).toLowerCase();
   }
-  const hasSa =
-    message.includes("serviceaccount") ||
-    message.includes("service account") ||
-    /\b[a-z0-9._%+-]+@[a-z0-9.-]+\.gserviceaccount\.com\b/i.test(message) ||
-    /\bgserviceaccount\.com\b/i.test(message);
+  const hasSa = message.includes("serviceaccount") || message.includes("service account");
 
   if (!hasSa) {
     return false;

--- a/src/deploy/functions/release/fabricator.spec.ts
+++ b/src/deploy/functions/release/fabricator.spec.ts
@@ -710,10 +710,10 @@ describe("Fabricator", () => {
         functionExecutor: queueExec,
       });
 
-      const saError: any = new Error(
+      const saError = new FirebaseError(
         "Validation failed for trigger: The request was invalid: invalid service account firebase-fn-123@proj.iam.gserviceaccount.com provided",
+        { status: 400 },
       );
-      saError.status = 400;
 
       gcfv2.createFunction.onFirstCall().rejects(saError);
       gcfv2.createFunction.onSecondCall().resolves({ name: "op", done: false });

--- a/src/deploy/functions/release/fabricator.spec.ts
+++ b/src/deploy/functions/release/fabricator.spec.ts
@@ -699,6 +699,34 @@ describe("Fabricator", () => {
       expect(gcfv2.createFunction).to.have.been.calledTwice;
     });
 
+    it("retries createV2Function and succeeds when service account 400 propagation error occurs", async () => {
+      const queueExec = new executor.QueueExecutor({
+        retries: 5,
+        backoff: 1,
+        maxBackoff: 1,
+      });
+      const fabWithQueue = new fabricator.Fabricator({
+        ...ctorArgs,
+        functionExecutor: queueExec,
+      });
+
+      const saError: any = new Error(
+        "Validation failed for trigger: The request was invalid: invalid service account firebase-fn-123@proj.iam.gserviceaccount.com provided",
+      );
+      saError.status = 400;
+
+      gcfv2.createFunction.onFirstCall().rejects(saError);
+      gcfv2.createFunction.onSecondCall().resolves({ name: "op", done: false });
+      poller.pollOperation.resolves({ serviceConfig: { service: "service" } });
+      run.setInvokerCreate.resolves();
+
+      const ep = endpoint({ httpsTrigger: {} }, { platform: "gcfv2" });
+      const sc = new scraper.SourceTokenScraper();
+      await fabWithQueue.createV2Function(ep, sc);
+
+      expect(gcfv2.createFunction).to.have.been.calledTwice;
+    });
+
     it("throws on set invoker failure", async () => {
       gcfv2.createFunction.resolves({ name: "op", done: false });
       poller.pollOperation.resolves({ serviceConfig: { service: "service" } });

--- a/src/deploy/functions/release/fabricator.ts
+++ b/src/deploy/functions/release/fabricator.ts
@@ -3,7 +3,7 @@ import * as clc from "colorette";
 import {
   Executor,
   isCloudRunResourceExhausted,
-  isServiceAccount404,
+  isServiceAccountPropagationError,
   isTransientError,
   parseErrorCode,
 } from "./executor";
@@ -253,7 +253,7 @@ export class Fabricator {
               serviceAccounts,
             }),
           {
-            retryPredicates: [isTransientError, isServiceAccount404],
+            retryPredicates: [isTransientError, isServiceAccountPropagationError],
           },
         ),
       ),
@@ -509,7 +509,7 @@ export class Fabricator {
               onPoll: scraper.poller,
             });
           }),
-        { retryPredicates: [isTransientError, isServiceAccount404] },
+        { retryPredicates: [isTransientError, isServiceAccountPropagationError] },
       )
       .catch(rethrowAs<gcf.CloudFunction>(endpoint, "create"));
 
@@ -647,7 +647,7 @@ export class Fabricator {
                 onPoll: scraper.poller,
               });
             }),
-          { retryPredicates: [isTransientError, isServiceAccount404] },
+          { retryPredicates: [isTransientError, isServiceAccountPropagationError] },
         )
         .catch(async (err: any) => {
           // If the createFunction call returns RPC error code RESOURCE_EXHAUSTED (8),
@@ -751,7 +751,7 @@ export class Fabricator {
               onPoll: scraper.poller,
             });
           }),
-        { retryPredicates: [isTransientError, isServiceAccount404] },
+        { retryPredicates: [isTransientError, isServiceAccountPropagationError] },
       )
       .catch(rethrowAs<gcf.CloudFunction>(endpoint, "update"));
 
@@ -810,7 +810,13 @@ export class Fabricator {
               onPoll: scraper.poller,
             });
           }),
-        { retryPredicates: [isTransientError, isCloudRunResourceExhausted, isServiceAccount404] },
+        {
+          retryPredicates: [
+            isTransientError,
+            isCloudRunResourceExhausted,
+            isServiceAccountPropagationError,
+          ],
+        },
       )
       .catch((err: any) => {
         logger.error((err as Error).message);
@@ -887,7 +893,13 @@ export class Fabricator {
           };
           await poller.pollOperation<void>(pollerOptions);
         },
-        { retryPredicates: [isTransientError, isCloudRunResourceExhausted, isServiceAccount404] },
+        {
+          retryPredicates: [
+            isTransientError,
+            isCloudRunResourceExhausted,
+            isServiceAccountPropagationError,
+          ],
+        },
       )
       .catch(rethrowAs(endpoint, "delete"));
   }
@@ -923,7 +935,7 @@ export class Fabricator {
           endpoint.uri = op.uri;
           endpoint.runServiceId = endpoint.id;
         },
-        { retryPredicates: [isTransientError, isServiceAccount404] },
+        { retryPredicates: [isTransientError, isServiceAccountPropagationError] },
       )
       .catch(rethrowAs(endpoint, "create"));
 


### PR DESCRIPTION
### Description
When deploying Cloud Functions with declarative security, the CLI provisions a dedicated managed service account (`firebase-fn-[0-9]+@<project>.iam.gserviceaccount.com`). While the service account is created and granted roles prior to function deployment, IAM propagation is eventually consistent across Google Cloud backend services.

When creating event-triggered Cloud Functions (such as Eventarc triggers), downstream validation can fail if the newly provisioned service account has not yet replicated to the trigger service. Because the trigger validator treats an unpropagated service account as an invalid request parameter rather than a missing URL resource, the API returns HTTP 400 (INVALID_ARGUMENT: "The request was invalid: invalid service account ... provided") rather than HTTP 404 (NOT_FOUND).

Previously, `executor.isServiceAccount404` only recognized HTTP 404 errors, causing function creation to fail immediately on HTTP 400 without retrying.

This change updates `isServiceAccount404` in `src/deploy/functions/release/executor.ts` to retry HTTP 400 errors caused by service account propagation delays. To prevent false positives and avoid retrying when a developer has made a typo in a custom service account configuration, HTTP 400 retries are specifically restricted to dynamically provisioned declarative security service accounts matching `firebase-fn-[0-9]+@`.

### Scenarios Tested
- Unit tests in `src/deploy/functions/release/executor.spec.ts` verifying:
  - Retry on HTTP 404 and HTTP 400 service account propagation errors for `firebase-fn-[0-9]+@` accounts
  - Immediate failure on HTTP 400 for user-configured custom service accounts without retrying
- Unit tests in `src/deploy/functions/release/fabricator.spec.ts` verifying:
  - QueueExecutor retries `createV2Function` and succeeds when encountering HTTP 400 service account propagation errors
- npm run test
- Manual testing deploying and deleting functions with kits.

### Sample Commands
firebase deploy --only functions:storage-resize-images
