### PR TITLE
fix(functions): clean up managed service accounts on declarative opt-out during filtered multi-codebase deploys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- [fixed] Clean up managed service accounts when opting out of declarative security alongside a filtered codebase deploy.

--- a/src/deploy/functions/functionsDeployHelper.spec.ts
+++ b/src/deploy/functions/functionsDeployHelper.spec.ts
@@ -642,4 +642,40 @@ describe("functionsDeployHelper", () => {
       expect(collisions).to.be.empty;
     });
   });
+
+  describe("isCodebasePartiallyFiltered", () => {
+    it("should return false when filters is undefined or empty", () => {
+      expect(helper.isCodebasePartiallyFiltered("codebaseA")).to.be.false;
+      expect(helper.isCodebasePartiallyFiltered("codebaseA", [])).to.be.false;
+    });
+
+    it("should return false when a filter targets the whole codebase without idChunks", () => {
+      expect(helper.isCodebasePartiallyFiltered("codebaseA", [{ codebase: "codebaseA" }])).to.be
+        .false;
+      expect(
+        helper.isCodebasePartiallyFiltered("codebaseA", [{ codebase: "codebaseA", idChunks: [] }]),
+      ).to.be.false;
+    });
+
+    it("should return false when filter with idChunks targets a different codebase", () => {
+      expect(
+        helper.isCodebasePartiallyFiltered("codebaseA", [
+          { codebase: "codebaseA" },
+          { codebase: "codebaseB", idChunks: ["funcB"] },
+        ]),
+      ).to.be.false;
+    });
+
+    it("should return true when filter with idChunks targets this codebase", () => {
+      expect(
+        helper.isCodebasePartiallyFiltered("codebaseA", [
+          { codebase: "codebaseA", idChunks: ["funcA"] },
+        ]),
+      ).to.be.true;
+    });
+
+    it("should return true when filter with idChunks has no codebase (wildcard filter)", () => {
+      expect(helper.isCodebasePartiallyFiltered("codebaseA", [{ idChunks: ["funcA"] }])).to.be.true;
+    });
+  });
 });

--- a/src/deploy/functions/functionsDeployHelper.ts
+++ b/src/deploy/functions/functionsDeployHelper.ts
@@ -249,6 +249,16 @@ export function isEndpointFiltered(endpoint: backend.Endpoint, filters: Endpoint
   return filters.some((filter) => endpointMatchesFilter(endpoint, filter));
 }
 
+/** Checks if a codebase has any intra-codebase (partial) filters targeting specific function IDs. */
+export function isCodebasePartiallyFiltered(codebase: string, filters?: EndpointFilter[]): boolean {
+  if (!filters) {
+    return false;
+  }
+  return filters.some(
+    (f) => (!f.codebase || f.codebase === codebase) && !!f.idChunks && f.idChunks.length > 0,
+  );
+}
+
 /**
  * Parses raw CLI filter strings for functions:delete into EndpointFilter objects.
  *

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -28,6 +28,7 @@ import {
   endpointMatchesAnyFilter,
   getEndpointFilters,
   groupEndpointsByCodebase,
+  isCodebasePartiallyFiltered,
   targetCodebases,
 } from "./functionsDeployHelper";
 import { logLabeledBullet, logLabeledWarning } from "../../utils";
@@ -107,12 +108,7 @@ export async function discoverSecurityDetails(
     (e) => !!e.labels?.[DECLARATIVE_SECURITY_ETAG_LABEL],
   )?.labels?.[DECLARATIVE_SECURITY_ETAG_LABEL];
 
-  const isPartiallyFiltered = !!(
-    filters &&
-    filters.some(
-      (f) => (!f.codebase || f.codebase === codebase) && f.idChunks && f.idChunks.length > 0,
-    )
-  );
+  const isPartiallyFiltered = isCodebasePartiallyFiltered(codebase, filters);
   const isEnrolling = !!requiredRoles && !existingManagedSA;
   const isUnenrolling = !requiredRoles && !!existingManagedSA && !!haveRolesEtag;
 

--- a/src/deploy/functions/release/planner.spec.ts
+++ b/src/deploy/functions/release/planner.spec.ts
@@ -591,6 +591,24 @@ describe("planner", () => {
       );
     });
 
+    it("deletes the service account when opting out with a full codebase deploy alongside a filtered deploy in another codebase", async () => {
+      const wantBackend = backend.empty();
+      const haveBackend = backend.of(func("id", "region"));
+
+      const plan = await planner.createDeploymentPlan({
+        wantBackend,
+        haveBackend,
+        codebase: "codebaseA",
+        projectId: "my-project",
+        filters: [{ codebase: "codebaseA" }, { codebase: "codebaseB", idChunks: ["funcB"] }],
+        existingManagedSA: "firebase-fn-123@my-project.iam.gserviceaccount.com",
+      });
+
+      expect(plan.serviceAccountToDelete).to.equal(
+        "firebase-fn-123@my-project.iam.gserviceaccount.com",
+      );
+    });
+
     it("deletes the service account when opting out during an unfiltered deploy", async () => {
       const wantBackend = backend.empty();
       const haveBackend = backend.of(func("id", "region"));

--- a/src/deploy/functions/release/planner.ts
+++ b/src/deploy/functions/release/planner.ts
@@ -2,6 +2,7 @@ import {
   EndpointFilter,
   endpointMatchesAnyFilter,
   getFunctionLabel,
+  isCodebasePartiallyFiltered,
 } from "../functionsDeployHelper";
 import { isFirebaseManaged } from "../../../deploymentTool";
 import { FirebaseError } from "../../../error";
@@ -177,11 +178,7 @@ export async function createDeploymentPlan(args: PlanArgs): Promise<CodebasePlan
   let serviceAccountToCreate: string | undefined;
   let serviceAccountToDelete: string | undefined;
 
-  const isFiltered = !!(
-    filters &&
-    filters.some((f) => f.idChunks && f.idChunks.length > 0) &&
-    !deleteAll
-  );
+  const isPartiallyFiltered = isCodebasePartiallyFiltered(codebase, filters);
 
   const hasWantEndpoints = backend.someEndpoint(wantBackend, () => true);
 
@@ -191,7 +188,7 @@ export async function createDeploymentPlan(args: PlanArgs): Promise<CodebasePlan
     if (!existingManagedSA && managedSA) {
       serviceAccountToCreate = managedSA;
     }
-  } else if (existingManagedSA && !isFiltered) {
+  } else if (existingManagedSA && (!isPartiallyFiltered || deleteAll)) {
     serviceAccountToDelete = existingManagedSA;
   }
 


### PR DESCRIPTION
### Description
When deploying multiple codebases where one codebase opts out of declarative security while another codebase uses a partial function filter (e.g. `--only functions:codebaseA,functions:codebaseB:funcB`), `prepare.ts` scoped its partial-filter check to `codebaseA`, discovering the unenrollment and updating functions to remove declarative labels and IAM bindings.

However, `planner.ts` checked function filters globally across all codebases. This marked `codebaseA` as partially filtered, suppressing deletion of the managed service account and permanently orphaning it in GCP IAM.

This change:
- Extracts `isCodebasePartiallyFiltered(codebase, filters)` into `functionsDeployHelper.ts` to share consistent codebase-scoped partial-filter evaluation across discovery (`prepare.ts`) and planning (`planner.ts`).
- Updates the deployment planner to scope partial-filter checks to the target codebase, ensuring the managed service account is deleted during opt-out unless that specific codebase is partially filtered.

### Scenarios Tested
- **Unit tests**:
  - `src/deploy/functions/functionsDeployHelper.spec.ts`: Added tests for `isCodebasePartiallyFiltered` covering undefined/empty filters, full codebase filters, foreign codebase partial filters, matching partial filters, and wildcard partial filters.
  - `src/deploy/functions/release/planner.spec.ts`: Added regression test verifying that opting out of a whole codebase alongside a filtered codebase deploy schedules the managed service account for deletion.
- `npm test`

### Sample Commands
```bash
firebase deploy --only functions:codebaseA,functions:codebaseB:funcB
firebase deploy --only functions:codebaseA
```
