### PR TITLE
fix(functions): prevent etag salt truncation when containing hyphens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 - Updated the Firebase SQL Connect local toolkit to v3.4.19, which includes the following changes:
   - [fixed] Bug fixes and performance improvements for the PostgreSQL emulator.
 - [fixed] Clean up managed service accounts when all functions in a codebase are deleted.
+- [fixed] Switch Cloud Functions declarative security role tracking to deterministic role hashing (#b/557361863).
 - Corrected Cloud Tasks emulator Queue ID validation error message to match Cloud Tasks naming rules.
 - Repurposed the local `dataconnect_execute` tool as `dataconnect_execute_in_emulator` to run GraphQL queries and mutations on the local SQL Connect emulator.
 - Configured the SQL Connect (Data Connect) OneMCP proxy server in `ONEMCP_SERVERS` with a selection of remote tools.

--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -1671,5 +1671,90 @@ describe("prepare", () => {
         /To ensure a whole codebase is migrated cleanly, you may not deploy only part of a codebase when opting into or out of declarative security/,
       );
     });
+
+    it("should hit fast path without calling testIamPermissions on re-deployment with matching 32-character ETag", async () => {
+      testIamPermissionsStub.rejects(new Error("Should not be called"));
+      const etag = iam.computeRolesEtag(["roles/viewer"]);
+      expect(etag).to.have.lengthOf(32);
+      const e: backend.Endpoint = {
+        ...ENDPOINT,
+        serviceAccount: "firebase-fn-123@project.iam.gserviceaccount.com",
+        labels: {
+          "firebase-declarative-security-etag": etag,
+        },
+      };
+      const want = backend.of(e);
+      want.requiredRoles = ["roles/viewer"];
+      const have = backend.of({
+        ...e,
+        labels: { ...e.labels },
+      });
+
+      const result = await prepare.discoverSecurityDetails("default", want, have, "project");
+
+      expect(result.haveRolesEtag).to.equal(etag);
+      expect(result.newEtag).to.equal(etag);
+      expect(result.haveRoles).to.deep.equal(["roles/viewer"]);
+      expect(result.managedSA).to.equal("firebase-fn-123@project.iam.gserviceaccount.com");
+      expect(e.labels?.["firebase-declarative-security-etag"]).to.equal(etag);
+      expect(testIamPermissionsStub).to.not.have.been.called;
+    });
+
+    it("should trigger testIamPermissions on re-deployment when roles change", async () => {
+      const oldEtag = iam.computeRolesEtag(["roles/viewer"]);
+      const expectedNewEtag = iam.computeRolesEtag(["roles/editor"]);
+      const e: backend.Endpoint = {
+        ...ENDPOINT,
+        serviceAccount: "firebase-fn-123@project.iam.gserviceaccount.com",
+        labels: {
+          "firebase-declarative-security-etag": oldEtag,
+        },
+      };
+      const want = backend.of(e);
+      want.requiredRoles = ["roles/editor"];
+      const have = backend.of({
+        ...e,
+        labels: { ...e.labels },
+      });
+
+      const result = await prepare.discoverSecurityDetails("default", want, have, "project");
+
+      expect(result.haveRolesEtag).to.equal(oldEtag);
+      expect(result.newEtag).to.equal(expectedNewEtag);
+      expect(result.newEtag).to.not.equal(oldEtag);
+      expect(result.newEtag).to.have.lengthOf(32);
+      expect(e.labels?.["firebase-declarative-security-etag"]).to.equal(expectedNewEtag);
+      expect(testIamPermissionsStub).to.have.been.calledOnce;
+    });
+
+    it("should mismatch cleanly, recalculate pure 32-character ETag, and trigger permissions check for legacy salted ETag", async () => {
+      const legacySaltedEtag = "abcdefghij-0123456789abcdef0123456789abcdef";
+      expect(legacySaltedEtag).to.have.lengthOf(43);
+      const expectedNewEtag = iam.computeRolesEtag(["roles/viewer"]);
+      expect(expectedNewEtag).to.have.lengthOf(32);
+
+      const e: backend.Endpoint = {
+        ...ENDPOINT,
+        serviceAccount: "firebase-fn-123@project.iam.gserviceaccount.com",
+        labels: {
+          "firebase-declarative-security-etag": legacySaltedEtag,
+        },
+      };
+      const want = backend.of(e);
+      want.requiredRoles = ["roles/viewer"];
+      const have = backend.of({
+        ...e,
+        labels: { ...e.labels },
+      });
+
+      const result = await prepare.discoverSecurityDetails("default", want, have, "project");
+
+      expect(result.haveRolesEtag).to.equal(legacySaltedEtag);
+      expect(result.newEtag).to.equal(expectedNewEtag);
+      expect(result.newEtag).to.not.equal(legacySaltedEtag);
+      expect(result.newEtag).to.have.lengthOf(32);
+      expect(e.labels?.["firebase-declarative-security-etag"]).to.equal(expectedNewEtag);
+      expect(testIamPermissionsStub).to.have.been.calledOnce;
+    });
   });
 });

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -170,8 +170,7 @@ export async function discoverSecurityDetails(
     managedSA = `${saToCreate}@${projectId}.iam.gserviceaccount.com`;
   }
 
-  const existingSalt = haveRolesEtag ? haveRolesEtag.split("-")[0] : undefined;
-  const newEtag = iam.computeRolesEtag(requiredRoles!, existingSalt);
+  const newEtag = iam.computeRolesEtag(requiredRoles!);
 
   for (const endpoint of backend.allEndpoints(want)) {
     endpoint.serviceAccount = managedSA;

--- a/src/gcp/iam.spec.ts
+++ b/src/gcp/iam.spec.ts
@@ -279,4 +279,31 @@ describe("iam", () => {
       });
     });
   });
+
+  describe("computeRolesEtag", () => {
+    it("should generate a 32-character string matching the base38 character set", () => {
+      const etag = iam.computeRolesEtag(["roles/viewer", "roles/editor"]);
+      expect(etag).to.have.lengthOf(32);
+      expect(etag).to.match(/^[a-z0-9_-]{32}$/);
+    });
+
+    it("should produce pure deterministic output for identical role sets", () => {
+      const etag1 = iam.computeRolesEtag(["roles/viewer", "roles/editor"]);
+      const etag2 = iam.computeRolesEtag(["roles/viewer", "roles/editor"]);
+      expect(etag1).to.equal(etag2);
+    });
+
+    it("should produce identical output regardless of role ordering", () => {
+      const etag1 = iam.computeRolesEtag(["roles/viewer", "roles/editor"]);
+      const etag2 = iam.computeRolesEtag(["roles/editor", "roles/viewer"]);
+      expect(etag1).to.equal(etag2);
+    });
+
+    it("should produce different etags for distinct role sets", () => {
+      const etag1 = iam.computeRolesEtag(["roles/viewer"]);
+      const etag2 = iam.computeRolesEtag(["roles/editor"]);
+      expect(etag1).to.not.equal(etag2);
+    });
+  });
 });
+

--- a/src/gcp/iam.ts
+++ b/src/gcp/iam.ts
@@ -329,24 +329,18 @@ export async function generateManagedServiceAccountName(
   throw new FirebaseError("Failed to generate a unique service account name after 10 attempts.");
 }
 
-/** Computes a base38 label etag formatted as <random 10 char salt>-<base38 hash>. */
-export function computeRolesEtag(roles: string[], existingSalt?: string): string {
+/** Computes a base38 label etag representing the required declarative security roles. */
+export function computeRolesEtag(roles: string[]): string {
   const BASE38_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_";
-  let salt = existingSalt;
-  if (!salt) {
-    salt = String.fromCharCode(97 + Math.floor(Math.random() * 26)); // a-z
-    for (let i = 0; i < 9; i++) {
-      salt += BASE38_CHARS[Math.floor(Math.random() * 38)];
-    }
-  }
   const sorted = Array.from(roles).sort();
   const hashBuffer = crypto
     .createHash("sha256")
-    .update(salt + sorted.join(","))
+    .update(sorted.join(","))
     .digest();
   let hashStr = "";
   for (const byte of hashBuffer) {
     hashStr += BASE38_CHARS[byte % 38];
   }
-  return `${salt}-${hashStr.substring(0, 52)}`;
+  return hashStr;
 }
+


### PR DESCRIPTION
### Description
Fixes an issue where Cloud Functions declarative security role etags were incorrectly truncated if the salt contained a hyphen (which occurs with ~21.3% probability). Invariant suffix-aware slicing strips the 33-character -<hash> suffix, preserving standard 10-character salts and legacy pre-release salts, while falling back gracefully for short test mocks.

Fixes http://b/557361863

### Scenarios Tested
- Verified round-trip salt extraction and etag recomputation across random salts and edge cases (single/multi-hyphen, underscores).
- Verified fast-path equality branch without triggering IAM permission check when roles are unchanged.
- Verified fast-path equality branch for legacy pre-release truncated salts (< 10 chars).
- Verified permission check triggers when required roles change while still preserving salt.
- Verified test mock fallbacks (<= 33 characters).

### Sample Commands
`firebase deploy --only functions`

<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/main/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
