### PR TITLE
fix(extensions): remove colliding -i short flag from ext:migrate --ext-instance option

### DIFF
--- a/src/commands/ext-migrate.ts
+++ b/src/commands/ext-migrate.ts
@@ -34,7 +34,7 @@ export interface ExtMigrateOptions extends Options {
 export const command = new Command("ext:migrate")
   .description("migrate an extension instance to a function kit")
   .option("-p, --package <package>", "optional kit package override to use")
-  .option("-i, --ext-instance <instanceId>", "extension instance ID to migrate")
+  .option("--ext-instance <instanceId>", "extension instance ID to migrate")
   .option("-e, --extension <extensionRef>", "extension reference or name to migrate")
   .option("-f, --force", "force update and migration without prompting")
   .before(requireConfig)


### PR DESCRIPTION
### Description
In `firebase ext:migrate`, the `--ext-instance <instanceId>` option was registered with the short flag `-i`. However, `-i, --interactive` is globally registered across all CLI commands in `src/index.ts`. 

Because Commander processes global options first, passing `-i <instanceId>` caused Commander to parse `-i` as the boolean `--interactive` flag, leaving the instance ID unconsumed or causing unexpected prompt behaviors/errors in scripted environments. Furthermore, `--help` actively advertised the broken `-i` short flag.

This PR removes the colliding `-i` short flag from `ext:migrate`, making `--ext-instance <instanceId>` the unambiguous option.

### Scenarios Tested
- Verified `firebase ext:migrate --help` displays `--ext-instance <instanceId>` without the conflicting `-i` shortcut.
- Ran unit tests via mocha: `npm test -- src/extensions/migrate.spec.ts` (38/38 passing).
- Verified migration runs cleanly with `--ext-instance <instanceId>`.

### Sample Commands
```bash
firebase ext:migrate --ext-instance storage-resize-images --project my-project
