### PR TITLE
fix(functions): honor non-string defaults in params select prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - [fixed] Clean up managed service accounts when opting out of declarative security alongside a filtered codebase deploy.
+- [fixed] Honor boolean and integer defaults in `select` prompts for function params instead of preselecting the first option.

--- a/src/deploy/functions/params.spec.ts
+++ b/src/deploy/functions/params.spec.ts
@@ -390,7 +390,12 @@ describe("resolveParams", () => {
           },
         },
       ];
-      const resolved = await params.resolveParams(paramsToResolve, fakeConfig, {}, "default");
+      const resolved = await params.resolveParams({
+        params: paramsToResolve,
+        firebaseConfig: fakeConfig,
+        userEnvs: {},
+        codebase: "default",
+      });
       expect(select.firstCall.args[0].default).to.equal("false");
       expect(resolved.paramValues.MAKE_PUBLIC).to.deep.equal(
         new params.ParamValue("false", false, { string: false, number: false, boolean: true }),
@@ -418,7 +423,12 @@ describe("resolveParams", () => {
           },
         },
       ];
-      const resolved = await params.resolveParams(paramsToResolve, fakeConfig, {}, "default");
+      const resolved = await params.resolveParams({
+        params: paramsToResolve,
+        firebaseConfig: fakeConfig,
+        userEnvs: {},
+        codebase: "default",
+      });
       expect(select.firstCall.args[0].default).to.equal("2");
       expect(resolved.paramValues.REPLICAS).to.deep.equal(
         new params.ParamValue("2", false, { string: false, number: true, boolean: false }),

--- a/src/deploy/functions/params.spec.ts
+++ b/src/deploy/functions/params.spec.ts
@@ -372,6 +372,62 @@ describe("resolveParams", () => {
     ).to.eventually.be.rejected;
   });
 
+  it("preselects a boolean default in a select prompt", async () => {
+    const select = sinon.stub(prompt, "select").resolves("false");
+    try {
+      const paramsToResolve: params.Param[] = [
+        {
+          name: "MAKE_PUBLIC",
+          type: "boolean",
+          default: false,
+          input: {
+            select: {
+              options: [
+                { label: "Yes", value: true },
+                { label: "No", value: false },
+              ],
+            },
+          },
+        },
+      ];
+      const resolved = await params.resolveParams(paramsToResolve, fakeConfig, {}, "default");
+      expect(select.firstCall.args[0].default).to.equal("false");
+      expect(resolved.paramValues.MAKE_PUBLIC).to.deep.equal(
+        new params.ParamValue("false", false, { string: false, number: false, boolean: true }),
+      );
+    } finally {
+      select.restore();
+    }
+  });
+
+  it("preselects an int default in a select prompt", async () => {
+    const select = sinon.stub(prompt, "select").resolves("2");
+    try {
+      const paramsToResolve: params.Param[] = [
+        {
+          name: "REPLICAS",
+          type: "int",
+          default: 2,
+          input: {
+            select: {
+              options: [
+                { label: "One", value: 1 },
+                { label: "Two", value: 2 },
+              ],
+            },
+          },
+        },
+      ];
+      const resolved = await params.resolveParams(paramsToResolve, fakeConfig, {}, "default");
+      expect(select.firstCall.args[0].default).to.equal("2");
+      expect(resolved.paramValues.REPLICAS).to.deep.equal(
+        new params.ParamValue("2", false, { string: false, number: true, boolean: false }),
+      );
+    } finally {
+      select.restore();
+    }
+  });
+
   it("does not throw in non-interactive mode if secret exists in cloud", async () => {
     const paramsToResolve: params.Param[] = [{ name: "MY_SECRET", type: "secret" }];
     const getSecretMetadataStub = sinon.stub(secretManager, "getSecretMetadata").resolves({

--- a/src/deploy/functions/params.ts
+++ b/src/deploy/functions/params.ts
@@ -931,7 +931,9 @@ async function promptSelect<T extends RawParamValue>(
   converter: (res: string) => T | retryInput,
 ): Promise<T> {
   const response = await select<string>({
-    default: resolvedDefault as string,
+    // Choice values are stringified below, so the default must be too or a
+    // boolean/number default never matches and the first option is preselected.
+    default: resolvedDefault?.toString(),
     message: prompt,
     choices: input.select.options.map((option: SelectOptions<T>): ListItem => {
       return {


### PR DESCRIPTION
### Description

`promptSelect` stringifies every choice value (`option.value.toString()`) but passed the resolved default to the `select` prompt unchanged. A boolean or integer default therefore never matched a choice, and inquirer fell back to preselecting the first option. In non-interactive mode the same raw default was handed straight to the converter, where `isTruthyInput` calls `.toLowerCase()` on it.

This stringifies the default the same way the choices are, so `defineBoolean`/`defineInt` params with a `select` input preselect their declared default. `promptSelectMultiple` was checked as well: its values are already strings (`T extends string`), so it is not affected by this particular mismatch.

Fixes #11053

### Scenarios Tested

- Added unit tests in `src/deploy/functions/params.spec.ts` covering a boolean select default (`false`) and an int select default (`2`), asserting the `default` passed to the prompt and the resolved `ParamValue`.
- `npx mocha src/deploy/functions/params.spec.ts`: 20 passing. Both new tests fail against `main` without the fix.

### Sample Commands

N/A — the change is in the interactive `firebase deploy --only functions` param prompt.
