### PR TITLE
fix(functions): fail-fast with actionable error when declarative security APIs are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- [fixed] Fail fast with an actionable error and remediation instructions when declarative security APIs (IAM and Cloud Resource Manager) are disabled on the project.
 - Updated the Firebase SQL Connect local toolkit to v3.4.19, which includes the following changes:
   - [fixed] Bug fixes and performance improvements for the PostgreSQL emulator.
 - [fixed] Clean up managed service accounts when all functions in a codebase are deleted.

--- a/src/deploy/functions/ensure.ts
+++ b/src/deploy/functions/ensure.ts
@@ -1,6 +1,6 @@
 import * as clc from "colorette";
 
-import { ensure } from "../../ensureApiEnabled";
+import * as ensureApiEnabled from "../../ensureApiEnabled";
 import { FirebaseError, isBillingError } from "../../error";
 import { logLabeledBullet, logLabeledSuccess } from "../../utils";
 import { checkServiceAgentRole, ensureServiceAgentRole } from "../../gcp/secretManager";
@@ -9,6 +9,7 @@ import { assertExhaustive } from "../../functional";
 import { cloudbuildOrigin } from "../../api";
 import * as backend from "./backend";
 import { getDefaultServiceAccount } from "../../gcp/computeEngine";
+import { logger } from "../../logger";
 
 const FAQ_URL = "https://firebase.google.com/support/faq#functions-runtime";
 
@@ -73,7 +74,7 @@ function isPermissionError(e: { context?: { body?: { error?: { status?: string }
  */
 export async function cloudBuildEnabled(projectId: string): Promise<void> {
   try {
-    await ensure(projectId, cloudbuildOrigin(), "functions");
+    await ensureApiEnabled.ensure(projectId, cloudbuildOrigin(), "functions");
   } catch (e: any) {
     if (isBillingError(e)) {
       throw nodeBillingError(projectId);
@@ -185,4 +186,59 @@ export async function grantSecretAccess(args: {
     "functions",
     `ensured ${clc.bold(serviceAccounts.join(", "))} access to ${clc.bold(secret)}.`,
   );
+}
+
+export const REQUIRED_SECURITY_APIS = [
+  "iam.googleapis.com",
+  "cloudresourcemanager.googleapis.com",
+] as const;
+
+/**
+ * Validates that the Google Cloud APIs required for Declarative Security are enabled.
+ * Fails fast with an actionable gcloud command and console URLs if either API is disabled.
+ */
+export async function checkDeclarativeSecurityApisEnabled(
+  projectId: string,
+  codebase: string,
+): Promise<void> {
+  const checks = await Promise.all(
+    REQUIRED_SECURITY_APIS.map(async (api) => {
+      try {
+        return await ensureApiEnabled.check(projectId, api, "functions", /* silent= */ true);
+      } catch (err: unknown) {
+        const isPermissionDenied =
+          (err as { status?: number })?.status === 403 ||
+          isPermissionError(err as { context?: { body?: { error?: { status?: string } } } });
+        if (isPermissionDenied) {
+          logger.debug(`Silencing permission error checking enablement for API ${api}:`, err);
+          return true;
+        }
+        throw err;
+      }
+    }),
+  );
+  const disabledApis = REQUIRED_SECURITY_APIS.filter((_, idx) => !checks[idx]);
+
+  if (disabledApis.length > 0) {
+    const apiBulletList = disabledApis.map((api) => `  - ${clc.bold(api)}`).join("\n");
+    const enableCmd = clc.bold(
+      `gcloud services enable ${disabledApis.join(" ")} --project ${projectId}`,
+    );
+    const consoleLinks = disabledApis
+      .map((api) => `  - ${api}: ${ensureApiEnabled.enableApiURI(projectId, api)}`)
+      .join("\n");
+
+    throw new FirebaseError(
+      `Cannot deploy functions with declarative security in codebase "${codebase}". ` +
+        `The following required Google Cloud API(s) are not enabled on project ${clc.bold(projectId)}:\n` +
+        apiBulletList +
+        `\n\nDeclarative security requires these APIs to provision and configure managed service accounts and IAM roles.\n` +
+        `To enable them, run:\n\n` +
+        `  ${enableCmd}\n\n` +
+        `Or ask a project owner to enable them in the Google Cloud Console:\n` +
+        consoleLinks +
+        `\n`,
+      { exit: 1 },
+    );
+  }
 }

--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -1483,6 +1483,8 @@ describe("prepare", () => {
 
   describe("discoverSecurityDetails", () => {
     let testIamPermissionsStub: sinon.SinonStub;
+    let checkApiStub: sinon.SinonStub;
+    let uncacheApiStub: sinon.SinonStub;
 
     beforeEach(() => {
       testIamPermissionsStub = sinon
@@ -1490,6 +1492,8 @@ describe("prepare", () => {
         .resolves({ passed: true } as any);
       sinon.stub(iam, "generateManagedServiceAccountName").resolves("firebase-fn-123");
       sinon.stub(resourcemanager, "getServiceAccountRoles").resolves([]);
+      checkApiStub = sinon.stub(ensureApiEnabled, "check").resolves(true);
+      uncacheApiStub = sinon.stub(ensureApiEnabled, "uncacheEnabledAPI");
     });
 
     afterEach(() => {
@@ -1670,6 +1674,226 @@ describe("prepare", () => {
         FirebaseError,
         /To ensure a whole codebase is migrated cleanly, you may not deploy only part of a codebase when opting into or out of declarative security/,
       );
+    });
+
+    describe("API enablement checks", () => {
+      it("should throw actionable error when both iam and cloudresourcemanager APIs are disabled", async () => {
+        checkApiStub.callsFake((projectId: string, api: string) => {
+          if (api === "iam.googleapis.com" || api === "cloudresourcemanager.googleapis.com") {
+            return Promise.resolve(false);
+          }
+          return Promise.resolve(true);
+        });
+
+        const e: backend.Endpoint = { ...ENDPOINT };
+        const want = backend.of(e);
+        want.requiredRoles = ["roles/viewer"];
+        const have = backend.empty();
+
+        let error: FirebaseError | undefined;
+        try {
+          await prepare.discoverSecurityDetails("default", want, have, "test-project");
+        } catch (err) {
+          if (err instanceof FirebaseError) {
+            error = err;
+          }
+        }
+
+        expect(error).to.be.instanceOf(FirebaseError);
+        expect(error!.message).to.include(
+          'Cannot deploy functions with declarative security in codebase "default"',
+        );
+        expect(error!.message).to.include("iam.googleapis.com");
+        expect(error!.message).to.include("cloudresourcemanager.googleapis.com");
+        expect(error!.message).to.include(
+          "gcloud services enable iam.googleapis.com cloudresourcemanager.googleapis.com --project test-project",
+        );
+        expect(error!.message).to.include(
+          "https://console.cloud.google.com/apis/library/iam.googleapis.com?project=test-project",
+        );
+        expect(error!.message).to.include(
+          "https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com?project=test-project",
+        );
+        expect(testIamPermissionsStub).to.not.have.been.called;
+      });
+
+      it("should throw actionable error when only iam API is disabled", async () => {
+        checkApiStub.callsFake((projectId: string, api: string) => {
+          if (api === "iam.googleapis.com") {
+            return Promise.resolve(false);
+          }
+          return Promise.resolve(true);
+        });
+
+        const e: backend.Endpoint = { ...ENDPOINT };
+        const want = backend.of(e);
+        want.requiredRoles = ["roles/viewer"];
+        const have = backend.empty();
+
+        let error: FirebaseError | undefined;
+        try {
+          await prepare.discoverSecurityDetails("default", want, have, "test-project");
+        } catch (err) {
+          if (err instanceof FirebaseError) {
+            error = err;
+          }
+        }
+
+        expect(error).to.be.instanceOf(FirebaseError);
+        expect(error!.message).to.include("iam.googleapis.com");
+        expect(error!.message).to.not.include("cloudresourcemanager.googleapis.com");
+        expect(error!.message).to.include(
+          "gcloud services enable iam.googleapis.com --project test-project",
+        );
+        expect(error!.message).to.include(
+          "https://console.cloud.google.com/apis/library/iam.googleapis.com?project=test-project",
+        );
+      });
+
+      it("should throw actionable error when only cloudresourcemanager API is disabled", async () => {
+        checkApiStub.callsFake((projectId: string, api: string) => {
+          if (api === "cloudresourcemanager.googleapis.com") {
+            return Promise.resolve(false);
+          }
+          return Promise.resolve(true);
+        });
+
+        const e: backend.Endpoint = { ...ENDPOINT };
+        const want = backend.of(e);
+        want.requiredRoles = ["roles/viewer"];
+        const have = backend.empty();
+
+        let error: FirebaseError | undefined;
+        try {
+          await prepare.discoverSecurityDetails("default", want, have, "test-project");
+        } catch (err) {
+          if (err instanceof FirebaseError) {
+            error = err;
+          }
+        }
+
+        expect(error).to.be.instanceOf(FirebaseError);
+        expect(error!.message).to.include("cloudresourcemanager.googleapis.com");
+        expect(error!.message).to.not.include("iam.googleapis.com");
+        expect(error!.message).to.include(
+          "gcloud services enable cloudresourcemanager.googleapis.com --project test-project",
+        );
+        expect(error!.message).to.include(
+          "https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com?project=test-project",
+        );
+      });
+
+      it("should not check security APIs when codebase does not use declarative security", async () => {
+        const e: backend.Endpoint = { ...ENDPOINT };
+        const want = backend.of(e);
+        const have = backend.empty();
+
+        await prepare.discoverSecurityDetails("default", want, have, "test-project");
+
+        expect(checkApiStub).to.not.have.been.calledWith("test-project", "iam.googleapis.com");
+        expect(checkApiStub).to.not.have.been.calledWith(
+          "test-project",
+          "cloudresourcemanager.googleapis.com",
+        );
+      });
+
+      it("should not block unenrollment even if security APIs are disabled", async () => {
+        checkApiStub.resolves(false);
+
+        const e: backend.Endpoint = {
+          ...ENDPOINT,
+          serviceAccount: "firebase-fn-123@project.iam.gserviceaccount.com",
+          labels: {
+            "firebase-declarative-security-etag": "salt-etag",
+          },
+        };
+        const want = backend.of(e);
+        const have = backend.of({
+          ...e,
+          labels: { ...e.labels },
+        });
+
+        const result = await prepare.discoverSecurityDetails("default", want, have, "project");
+        expect(result.existingManagedSA).to.equal(
+          "firebase-fn-123@project.iam.gserviceaccount.com",
+        );
+        expect(e.serviceAccount).to.be.null;
+      });
+
+      it("should catch downstream testIamPermissions 403 error due to disabled cloudresourcemanager, uncache API, and throw actionable error", async () => {
+        checkApiStub.resolves(true);
+        const disabledError = new FirebaseError(
+          "HTTP Error: 403, Cloud Resource Manager API has not been used in project test-project before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/cloudresourcemanager.googleapis.com/overview?project=test-project then retry.",
+          { status: 403 },
+        );
+        testIamPermissionsStub.rejects(disabledError);
+
+        const e: backend.Endpoint = { ...ENDPOINT };
+        const want = backend.of(e);
+        want.requiredRoles = ["roles/viewer"];
+        const have = backend.empty();
+
+        let error: FirebaseError | undefined;
+        try {
+          await prepare.discoverSecurityDetails("default", want, have, "test-project");
+        } catch (err) {
+          if (err instanceof FirebaseError) {
+            error = err;
+          }
+        }
+
+        expect(error).to.be.instanceOf(FirebaseError);
+        expect(uncacheApiStub).to.have.been.calledWith(
+          "test-project",
+          "cloudresourcemanager.googleapis.com",
+        );
+        expect(error!.message).to.include(
+          "Cloud Resource Manager API (cloudresourcemanager.googleapis.com) is disabled on project test-project",
+        );
+        expect(error!.message).to.include(
+          "gcloud services enable cloudresourcemanager.googleapis.com --project test-project",
+        );
+        expect(error!.message).to.include(
+          "https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com?project=test-project",
+        );
+      });
+    });
+
+    describe("isServiceDisabledError", () => {
+      it("should return true when error details contains SERVICE_DISABLED", () => {
+        const err = {
+          context: {
+            body: {
+              error: {
+                details: [
+                  {
+                    reason: "SERVICE_DISABLED",
+                    metadata: { service: "cloudresourcemanager.googleapis.com" },
+                  },
+                ],
+              },
+            },
+          },
+        };
+        expect(prepare.isServiceDisabledError(err, "cloudresourcemanager.googleapis.com")).to.be
+          .true;
+        expect(prepare.isServiceDisabledError(err, "iam.googleapis.com")).to.be.false;
+      });
+
+      it("should return true when error message matches disabled API format", () => {
+        const err = new Error(
+          "Cloud Resource Manager API has not been used in project 12345 before or it is disabled.",
+        );
+        expect(prepare.isServiceDisabledError(err, "Cloud Resource Manager API")).to.be.true;
+        expect(prepare.isServiceDisabledError(err)).to.be.true;
+      });
+
+      it("should return false for unrelated errors", () => {
+        const err = new Error("Permission denied: user does not have permission");
+        expect(prepare.isServiceDisabledError(err)).to.be.false;
+        expect(prepare.isServiceDisabledError(err, "cloudresourcemanager.googleapis.com")).to.be
+          .false;
+      });
     });
   });
 });

--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -1484,7 +1484,6 @@ describe("prepare", () => {
   describe("discoverSecurityDetails", () => {
     let testIamPermissionsStub: sinon.SinonStub;
     let checkApiStub: sinon.SinonStub;
-    let uncacheApiStub: sinon.SinonStub;
 
     beforeEach(() => {
       testIamPermissionsStub = sinon
@@ -1493,7 +1492,6 @@ describe("prepare", () => {
       sinon.stub(iam, "generateManagedServiceAccountName").resolves("firebase-fn-123");
       sinon.stub(resourcemanager, "getServiceAccountRoles").resolves([]);
       checkApiStub = sinon.stub(ensureApiEnabled, "check").resolves(true);
-      uncacheApiStub = sinon.stub(ensureApiEnabled, "uncacheEnabledAPI");
     });
 
     afterEach(() => {
@@ -1836,87 +1834,6 @@ describe("prepare", () => {
         expect(e.serviceAccount).to.be.null;
       });
 
-      it("should catch downstream testIamPermissions 403 error due to disabled cloudresourcemanager, uncache API, and throw actionable error", async () => {
-        checkApiStub.resolves(true);
-        const disabledError = new FirebaseError(
-          "HTTP Error: 403, Cloud Resource Manager API has not been used in project test-project before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/cloudresourcemanager.googleapis.com/overview?project=test-project then retry.",
-          { status: 403 },
-        );
-        testIamPermissionsStub.rejects(disabledError);
-
-        const e: backend.Endpoint = { ...ENDPOINT };
-        const want = backend.of(e);
-        want.requiredRoles = ["roles/viewer"];
-        const have = backend.empty();
-
-        let error: FirebaseError | undefined;
-        try {
-          await prepare.discoverSecurityDetails("default", want, have, "test-project");
-        } catch (err) {
-          if (err instanceof FirebaseError) {
-            error = err;
-          }
-        }
-
-        expect(error).to.be.instanceOf(FirebaseError);
-        expect(uncacheApiStub).to.have.been.calledWith(
-          "test-project",
-          "cloudresourcemanager.googleapis.com",
-        );
-        expect(error!.message).to.include(
-          "Cloud Resource Manager API (cloudresourcemanager.googleapis.com) is disabled on project test-project",
-        );
-        expect(error!.message).to.include(
-          "gcloud services enable cloudresourcemanager.googleapis.com --project test-project",
-        );
-        expect(error!.message).to.include(
-          "https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com?project=test-project",
-        );
-      });
-    });
-
-    describe("isServiceDisabledError", () => {
-      it("should return true when error details contains SERVICE_DISABLED", () => {
-        const err = {
-          context: {
-            body: {
-              error: {
-                details: [
-                  {
-                    reason: "SERVICE_DISABLED",
-                    metadata: { service: "cloudresourcemanager.googleapis.com" },
-                  },
-                ],
-              },
-            },
-          },
-        };
-        expect(prepare.isServiceDisabledError(err, "cloudresourcemanager.googleapis.com")).to.be
-          .true;
-        expect(prepare.isServiceDisabledError(err, "iam.googleapis.com")).to.be.false;
-      });
-
-      it("should return true when error message matches disabled API format", () => {
-        const err = new Error(
-          "Cloud Resource Manager API has not been used in project 12345 before or it is disabled.",
-        );
-        expect(prepare.isServiceDisabledError(err, "Cloud Resource Manager API")).to.be.true;
-        expect(prepare.isServiceDisabledError(err, "cloudresourcemanager.googleapis.com")).to.be
-          .true;
-        expect(prepare.isServiceDisabledError(err)).to.be.true;
-
-        const iamErr = new Error(
-          "Identity and Access Management API has not been used in project 12345 before or it is disabled.",
-        );
-        expect(prepare.isServiceDisabledError(iamErr, "iam.googleapis.com")).to.be.true;
-      });
-
-      it("should return false for unrelated errors", () => {
-        const err = new Error("Permission denied: user does not have permission");
-        expect(prepare.isServiceDisabledError(err)).to.be.false;
-        expect(prepare.isServiceDisabledError(err, "cloudresourcemanager.googleapis.com")).to.be
-          .false;
-      });
     });
   });
 });

--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -1698,18 +1698,18 @@ describe("prepare", () => {
         }
 
         expect(error).to.be.instanceOf(FirebaseError);
-        expect(error!.message).to.include(
+        expect(error?.message).to.include(
           'Cannot deploy functions with declarative security in codebase "default"',
         );
-        expect(error!.message).to.include("iam.googleapis.com");
-        expect(error!.message).to.include("cloudresourcemanager.googleapis.com");
-        expect(error!.message).to.include(
+        expect(error?.message).to.include("iam.googleapis.com");
+        expect(error?.message).to.include("cloudresourcemanager.googleapis.com");
+        expect(error?.message).to.include(
           "gcloud services enable iam.googleapis.com cloudresourcemanager.googleapis.com --project test-project",
         );
-        expect(error!.message).to.include(
+        expect(error?.message).to.include(
           "https://console.cloud.google.com/apis/library/iam.googleapis.com?project=test-project",
         );
-        expect(error!.message).to.include(
+        expect(error?.message).to.include(
           "https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com?project=test-project",
         );
         expect(testIamPermissionsStub).to.not.have.been.called;
@@ -1738,12 +1738,12 @@ describe("prepare", () => {
         }
 
         expect(error).to.be.instanceOf(FirebaseError);
-        expect(error!.message).to.include("iam.googleapis.com");
-        expect(error!.message).to.not.include("cloudresourcemanager.googleapis.com");
-        expect(error!.message).to.include(
+        expect(error?.message).to.include("iam.googleapis.com");
+        expect(error?.message).to.not.include("cloudresourcemanager.googleapis.com");
+        expect(error?.message).to.include(
           "gcloud services enable iam.googleapis.com --project test-project",
         );
-        expect(error!.message).to.include(
+        expect(error?.message).to.include(
           "https://console.cloud.google.com/apis/library/iam.googleapis.com?project=test-project",
         );
       });
@@ -1771,12 +1771,12 @@ describe("prepare", () => {
         }
 
         expect(error).to.be.instanceOf(FirebaseError);
-        expect(error!.message).to.include("cloudresourcemanager.googleapis.com");
-        expect(error!.message).to.not.include("iam.googleapis.com");
-        expect(error!.message).to.include(
+        expect(error?.message).to.include("cloudresourcemanager.googleapis.com");
+        expect(error?.message).to.not.include("iam.googleapis.com");
+        expect(error?.message).to.include(
           "gcloud services enable cloudresourcemanager.googleapis.com --project test-project",
         );
-        expect(error!.message).to.include(
+        expect(error?.message).to.include(
           "https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com?project=test-project",
         );
       });
@@ -1833,7 +1833,6 @@ describe("prepare", () => {
         );
         expect(e.serviceAccount).to.be.null;
       });
-
     });
   });
 });

--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -1676,12 +1676,7 @@ describe("prepare", () => {
 
     describe("API enablement checks", () => {
       it("should throw actionable error when both iam and cloudresourcemanager APIs are disabled", async () => {
-        checkApiStub.callsFake((projectId: string, api: string) => {
-          if (api === "iam.googleapis.com" || api === "cloudresourcemanager.googleapis.com") {
-            return Promise.resolve(false);
-          }
-          return Promise.resolve(true);
-        });
+        checkApiStub.resolves(false);
 
         const e: backend.Endpoint = { ...ENDPOINT };
         const want = backend.of(e);
@@ -1698,30 +1693,16 @@ describe("prepare", () => {
         }
 
         expect(error).to.be.instanceOf(FirebaseError);
-        expect(error?.message).to.include(
-          'Cannot deploy functions with declarative security in codebase "default"',
-        );
         expect(error?.message).to.include("iam.googleapis.com");
         expect(error?.message).to.include("cloudresourcemanager.googleapis.com");
         expect(error?.message).to.include(
           "gcloud services enable iam.googleapis.com cloudresourcemanager.googleapis.com --project test-project",
         );
-        expect(error?.message).to.include(
-          "https://console.cloud.google.com/apis/library/iam.googleapis.com?project=test-project",
-        );
-        expect(error?.message).to.include(
-          "https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com?project=test-project",
-        );
         expect(testIamPermissionsStub).to.not.have.been.called;
       });
 
       it("should throw actionable error when only iam API is disabled", async () => {
-        checkApiStub.callsFake((projectId: string, api: string) => {
-          if (api === "iam.googleapis.com") {
-            return Promise.resolve(false);
-          }
-          return Promise.resolve(true);
-        });
+        checkApiStub.withArgs("test-project", "iam.googleapis.com").resolves(false);
 
         const e: backend.Endpoint = { ...ENDPOINT };
         const want = backend.of(e);
@@ -1743,18 +1724,12 @@ describe("prepare", () => {
         expect(error?.message).to.include(
           "gcloud services enable iam.googleapis.com --project test-project",
         );
-        expect(error?.message).to.include(
-          "https://console.cloud.google.com/apis/library/iam.googleapis.com?project=test-project",
-        );
       });
 
       it("should throw actionable error when only cloudresourcemanager API is disabled", async () => {
-        checkApiStub.callsFake((projectId: string, api: string) => {
-          if (api === "cloudresourcemanager.googleapis.com") {
-            return Promise.resolve(false);
-          }
-          return Promise.resolve(true);
-        });
+        checkApiStub
+          .withArgs("test-project", "cloudresourcemanager.googleapis.com")
+          .resolves(false);
 
         const e: backend.Endpoint = { ...ENDPOINT };
         const want = backend.of(e);
@@ -1775,9 +1750,6 @@ describe("prepare", () => {
         expect(error?.message).to.not.include("iam.googleapis.com");
         expect(error?.message).to.include(
           "gcloud services enable cloudresourcemanager.googleapis.com --project test-project",
-        );
-        expect(error?.message).to.include(
-          "https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com?project=test-project",
         );
       });
 
@@ -1809,6 +1781,19 @@ describe("prepare", () => {
 
         const result = await prepare.discoverSecurityDetails("default", want, have, "test-project");
         expect(result.managedSA).to.equal("firebase-fn-123@test-project.iam.gserviceaccount.com");
+      });
+
+      it("should rethrow unexpected non-permission errors when checking API enablement", async () => {
+        checkApiStub.rejects(new Error("Network timeout"));
+
+        const e: backend.Endpoint = { ...ENDPOINT };
+        const want = backend.of(e);
+        want.requiredRoles = ["roles/viewer"];
+        const have = backend.empty();
+
+        await expect(
+          prepare.discoverSecurityDetails("default", want, have, "test-project"),
+        ).to.be.rejectedWith(Error, "Network timeout");
       });
 
       it("should not block unenrollment even if security APIs are disabled", async () => {

--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -1797,6 +1797,22 @@ describe("prepare", () => {
         );
       });
 
+      it("should not block deployment if caller lacks permission to check API enablement", async () => {
+        checkApiStub.rejects(
+          new FirebaseError("HTTP Error: 403, PERMISSION_DENIED on serviceusage.services.get", {
+            status: 403,
+          }),
+        );
+
+        const e: backend.Endpoint = { ...ENDPOINT };
+        const want = backend.of(e);
+        want.requiredRoles = ["roles/viewer"];
+        const have = backend.empty();
+
+        const result = await prepare.discoverSecurityDetails("default", want, have, "test-project");
+        expect(result.managedSA).to.equal("firebase-fn-123@test-project.iam.gserviceaccount.com");
+      });
+
       it("should not block unenrollment even if security APIs are disabled", async () => {
         checkApiStub.resolves(false);
 
@@ -1885,7 +1901,14 @@ describe("prepare", () => {
           "Cloud Resource Manager API has not been used in project 12345 before or it is disabled.",
         );
         expect(prepare.isServiceDisabledError(err, "Cloud Resource Manager API")).to.be.true;
+        expect(prepare.isServiceDisabledError(err, "cloudresourcemanager.googleapis.com")).to.be
+          .true;
         expect(prepare.isServiceDisabledError(err)).to.be.true;
+
+        const iamErr = new Error(
+          "Identity and Access Management API has not been used in project 12345 before or it is disabled.",
+        );
+        expect(prepare.isServiceDisabledError(iamErr, "iam.googleapis.com")).to.be.true;
       });
 
       it("should return false for unrelated errors", () => {

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -69,6 +69,102 @@ import * as resourcemanager from "../../gcp/resourceManager";
 export const EVENTARC_SOURCE_ENV = "EVENTARC_CLOUD_EVENT_SOURCE";
 export const DECLARATIVE_SECURITY_ETAG_LABEL = "firebase-declarative-security-etag";
 
+const REQUIRED_SECURITY_APIS = [
+  "iam.googleapis.com",
+  "cloudresourcemanager.googleapis.com",
+] as const;
+
+/**
+ * Validates that the Google Cloud APIs required for Declarative Security are enabled.
+ * Fails fast with an actionable gcloud command and console URLs if either API is disabled.
+ */
+export async function checkDeclarativeSecurityApisEnabled(
+  projectId: string,
+  codebase: string,
+): Promise<void> {
+  const checks = await Promise.all(
+    REQUIRED_SECURITY_APIS.map((api) =>
+      ensureApiEnabled.check(projectId, api, "functions", /* silent= */ true),
+    ),
+  );
+  const disabledApis = REQUIRED_SECURITY_APIS.filter((_, idx) => !checks[idx]);
+
+  if (disabledApis.length > 0) {
+    const apiBulletList = disabledApis.map((api) => `  - ${clc.bold(api)}`).join("\n");
+    const enableCmd = clc.bold(
+      `gcloud services enable ${disabledApis.join(" ")} --project ${projectId}`,
+    );
+    const consoleLinks = disabledApis
+      .map((api) => `  - ${api}: ${ensureApiEnabled.enableApiURI(projectId, api)}`)
+      .join("\n");
+
+    throw new FirebaseError(
+      `Cannot deploy functions with declarative security in codebase "${codebase}". ` +
+        `The following required Google Cloud API(s) are not enabled on project ${clc.bold(projectId)}:\n` +
+        apiBulletList +
+        `\n\nDeclarative security requires these APIs to provision and configure managed service accounts and IAM roles.\n` +
+        `To enable them, run:\n\n` +
+        `  ${enableCmd}\n\n` +
+        `Or ask a project owner to enable them in the Google Cloud Console:\n` +
+        consoleLinks +
+        `\n`,
+      { exit: 1 },
+    );
+  }
+}
+
+interface ServiceErrorDetail {
+  reason?: string;
+  metadata?: {
+    service?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+interface ServiceErrorResponse {
+  message?: string;
+  context?: {
+    body?: {
+      error?: {
+        details?: ServiceErrorDetail[];
+      };
+    };
+  };
+  original?: ServiceErrorResponse;
+}
+
+/**
+ * Checks whether an error is caused by a Google Cloud service/API being disabled.
+ */
+export function isServiceDisabledError(err: unknown, service?: string): boolean {
+  const errorObj = err as ServiceErrorResponse;
+  const message = typeof errorObj?.message === "string" ? errorObj.message : "";
+  const details =
+    errorObj?.context?.body?.error?.details ||
+    errorObj?.original?.context?.body?.error?.details ||
+    [];
+  const hasServiceDisabledDetail =
+    Array.isArray(details) &&
+    details.some(
+      (d: ServiceErrorDetail) =>
+        d.reason === "SERVICE_DISABLED" && (!service || d.metadata?.service === service),
+    );
+  if (hasServiceDisabledDetail) {
+    return true;
+  }
+  if (service) {
+    return (
+      message.includes("has not been used in project") &&
+      message.includes("before or it is disabled") &&
+      message.includes(service)
+    );
+  }
+  return (
+    message.includes("has not been used in project") && message.includes("before or it is disabled")
+  );
+}
+
 /**
  * Discovers and coordinates declarative security details for a codebase.
  * Mutates `want` Backend to populate managed service account and etag labels.
@@ -164,6 +260,8 @@ export async function discoverSecurityDetails(
     };
   }
 
+  await checkDeclarativeSecurityApisEnabled(projectId, codebase);
+
   let managedSA = existingManagedSA;
   if (!managedSA) {
     const saToCreate = await iam.generateManagedServiceAccountName(projectId, "firebase-fn");
@@ -193,7 +291,30 @@ export async function discoverSecurityDetails(
   if (!existingManagedSA) {
     permissionsToTest.push("iam.serviceAccounts.create");
   }
-  const iamResult = await iam.testIamPermissions(projectId, permissionsToTest);
+  let iamResult;
+  try {
+    iamResult = await iam.testIamPermissions(projectId, permissionsToTest);
+  } catch (err: unknown) {
+    const errOriginal = err instanceof Error ? err : undefined;
+    if (isServiceDisabledError(err, "cloudresourcemanager.googleapis.com")) {
+      ensureApiEnabled.uncacheEnabledAPI(projectId, "cloudresourcemanager.googleapis.com");
+      const crmConsoleUrl = ensureApiEnabled.enableApiURI(
+        projectId,
+        "cloudresourcemanager.googleapis.com",
+      );
+      throw new FirebaseError(
+        `Cannot deploy functions with declarative security in codebase "${codebase}". ` +
+          `Cloud Resource Manager API (${clc.bold("cloudresourcemanager.googleapis.com")}) is disabled on project ${clc.bold(projectId)}.\n\n` +
+          `Declarative security requires this API to verify and update IAM policies.\n` +
+          `To enable it, run:\n\n` +
+          `  ${clc.bold(`gcloud services enable cloudresourcemanager.googleapis.com --project ${projectId}`)}\n\n` +
+          `Or ask a project owner to enable it in the Google Cloud Console:\n` +
+          `  - ${crmConsoleUrl}\n`,
+        { exit: 1, original: errOriginal },
+      );
+    }
+    throw err;
+  }
   if (!iamResult.passed) {
     if (!existingManagedSA) {
       throw new FirebaseError(

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -69,55 +69,6 @@ import * as resourcemanager from "../../gcp/resourceManager";
 export const EVENTARC_SOURCE_ENV = "EVENTARC_CLOUD_EVENT_SOURCE";
 export const DECLARATIVE_SECURITY_ETAG_LABEL = "firebase-declarative-security-etag";
 
-const REQUIRED_SECURITY_APIS = [
-  "iam.googleapis.com",
-  "cloudresourcemanager.googleapis.com",
-] as const;
-
-/**
- * Validates that the Google Cloud APIs required for Declarative Security are enabled.
- * Fails fast with an actionable gcloud command and console URLs if either API is disabled.
- */
-export async function checkDeclarativeSecurityApisEnabled(
-  projectId: string,
-  codebase: string,
-): Promise<void> {
-  const checks = await Promise.all(
-    REQUIRED_SECURITY_APIS.map(async (api) => {
-      try {
-        return await ensureApiEnabled.check(projectId, api, "functions", /* silent= */ true);
-      } catch (err) {
-        logger.debug(`Silence error checking enablement for API ${api}: ${String(err)}`);
-        return true;
-      }
-    }),
-  );
-  const disabledApis = REQUIRED_SECURITY_APIS.filter((_, idx) => !checks[idx]);
-
-  if (disabledApis.length > 0) {
-    const apiBulletList = disabledApis.map((api) => `  - ${clc.bold(api)}`).join("\n");
-    const enableCmd = clc.bold(
-      `gcloud services enable ${disabledApis.join(" ")} --project ${projectId}`,
-    );
-    const consoleLinks = disabledApis
-      .map((api) => `  - ${api}: ${ensureApiEnabled.enableApiURI(projectId, api)}`)
-      .join("\n");
-
-    throw new FirebaseError(
-      `Cannot deploy functions with declarative security in codebase "${codebase}". ` +
-        `The following required Google Cloud API(s) are not enabled on project ${clc.bold(projectId)}:\n` +
-        apiBulletList +
-        `\n\nDeclarative security requires these APIs to provision and configure managed service accounts and IAM roles.\n` +
-        `To enable them, run:\n\n` +
-        `  ${enableCmd}\n\n` +
-        `Or ask a project owner to enable them in the Google Cloud Console:\n` +
-        consoleLinks +
-        `\n`,
-      { exit: 1 },
-    );
-  }
-}
-
 /**
  * Discovers and coordinates declarative security details for a codebase.
  * Mutates `want` Backend to populate managed service account and etag labels.
@@ -213,7 +164,7 @@ export async function discoverSecurityDetails(
     };
   }
 
-  await checkDeclarativeSecurityApisEnabled(projectId, codebase);
+  await ensure.checkDeclarativeSecurityApisEnabled(projectId, codebase);
 
   let managedSA = existingManagedSA;
   if (!managedSA) {

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -118,64 +118,6 @@ export async function checkDeclarativeSecurityApisEnabled(
   }
 }
 
-const SERVICE_FRIENDLY_NAMES: Record<string, string> = {
-  "cloudresourcemanager.googleapis.com": "Cloud Resource Manager",
-  "iam.googleapis.com": "Identity and Access Management",
-};
-
-interface ServiceErrorDetail {
-  reason?: string;
-  metadata?: {
-    service?: string;
-    [key: string]: unknown;
-  };
-  [key: string]: unknown;
-}
-
-interface ServiceErrorResponse {
-  message?: string;
-  context?: {
-    body?: {
-      error?: {
-        details?: ServiceErrorDetail[];
-      };
-    };
-  };
-  original?: ServiceErrorResponse;
-}
-
-/**
- * Checks whether an error is caused by a Google Cloud service/API being disabled.
- */
-export function isServiceDisabledError(err: unknown, service?: string): boolean {
-  const errorObj = err as ServiceErrorResponse;
-  const message = typeof errorObj?.message === "string" ? errorObj.message : "";
-  const details =
-    errorObj?.context?.body?.error?.details ||
-    errorObj?.original?.context?.body?.error?.details ||
-    [];
-  const hasServiceDisabledDetail =
-    Array.isArray(details) &&
-    details.some(
-      (d: ServiceErrorDetail) =>
-        d.reason === "SERVICE_DISABLED" && (!service || d.metadata?.service === service),
-    );
-  if (hasServiceDisabledDetail) {
-    return true;
-  }
-  if (service) {
-    const friendlyName = SERVICE_FRIENDLY_NAMES[service];
-    return (
-      message.includes("has not been used in project") &&
-      message.includes("before or it is disabled") &&
-      (message.includes(service) || (!!friendlyName && message.includes(friendlyName)))
-    );
-  }
-  return (
-    message.includes("has not been used in project") && message.includes("before or it is disabled")
-  );
-}
-
 /**
  * Discovers and coordinates declarative security details for a codebase.
  * Mutates `want` Backend to populate managed service account and etag labels.
@@ -302,30 +244,7 @@ export async function discoverSecurityDetails(
   if (!existingManagedSA) {
     permissionsToTest.push("iam.serviceAccounts.create");
   }
-  let iamResult;
-  try {
-    iamResult = await iam.testIamPermissions(projectId, permissionsToTest);
-  } catch (err: unknown) {
-    const errOriginal = err instanceof Error ? err : undefined;
-    if (isServiceDisabledError(err, "cloudresourcemanager.googleapis.com")) {
-      ensureApiEnabled.uncacheEnabledAPI(projectId, "cloudresourcemanager.googleapis.com");
-      const crmConsoleUrl = ensureApiEnabled.enableApiURI(
-        projectId,
-        "cloudresourcemanager.googleapis.com",
-      );
-      throw new FirebaseError(
-        `Cannot deploy functions with declarative security in codebase "${codebase}". ` +
-          `Cloud Resource Manager API (${clc.bold("cloudresourcemanager.googleapis.com")}) is disabled on project ${clc.bold(projectId)}.\n\n` +
-          `Declarative security requires this API to verify and update IAM policies.\n` +
-          `To enable it, run:\n\n` +
-          `  ${clc.bold(`gcloud services enable cloudresourcemanager.googleapis.com --project ${projectId}`)}\n\n` +
-          `Or ask a project owner to enable it in the Google Cloud Console:\n` +
-          `  - ${crmConsoleUrl}\n`,
-        { exit: 1, original: errOriginal },
-      );
-    }
-    throw err;
-  }
+  const iamResult = await iam.testIamPermissions(projectId, permissionsToTest);
   if (!iamResult.passed) {
     if (!existingManagedSA) {
       throw new FirebaseError(

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -87,7 +87,7 @@ export async function checkDeclarativeSecurityApisEnabled(
       try {
         return await ensureApiEnabled.check(projectId, api, "functions", /* silent= */ true);
       } catch (err) {
-        logger.debug(`Silence error checking enablement for API ${api}: ${err}`);
+        logger.debug(`Silence error checking enablement for API ${api}: ${String(err)}`);
         return true;
       }
     }),

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -83,9 +83,14 @@ export async function checkDeclarativeSecurityApisEnabled(
   codebase: string,
 ): Promise<void> {
   const checks = await Promise.all(
-    REQUIRED_SECURITY_APIS.map((api) =>
-      ensureApiEnabled.check(projectId, api, "functions", /* silent= */ true),
-    ),
+    REQUIRED_SECURITY_APIS.map(async (api) => {
+      try {
+        return await ensureApiEnabled.check(projectId, api, "functions", /* silent= */ true);
+      } catch (err) {
+        logger.debug(`Silence error checking enablement for API ${api}: ${err}`);
+        return true;
+      }
+    }),
   );
   const disabledApis = REQUIRED_SECURITY_APIS.filter((_, idx) => !checks[idx]);
 
@@ -112,6 +117,11 @@ export async function checkDeclarativeSecurityApisEnabled(
     );
   }
 }
+
+const SERVICE_FRIENDLY_NAMES: Record<string, string> = {
+  "cloudresourcemanager.googleapis.com": "Cloud Resource Manager",
+  "iam.googleapis.com": "Identity and Access Management",
+};
 
 interface ServiceErrorDetail {
   reason?: string;
@@ -154,10 +164,11 @@ export function isServiceDisabledError(err: unknown, service?: string): boolean 
     return true;
   }
   if (service) {
+    const friendlyName = SERVICE_FRIENDLY_NAMES[service];
     return (
       message.includes("has not been used in project") &&
       message.includes("before or it is disabled") &&
-      message.includes(service)
+      (message.includes(service) || (!!friendlyName && message.includes(friendlyName)))
     );
   }
   return (


### PR DESCRIPTION
### Description

When deploying functions configured with Declarative Security (`requiresRole` / Function Kits), deployment requires:
1. `iam.googleapis.com`: To generate, inspect, and provision managed service accounts (`firebase-fn-...`).
2. `cloudresourcemanager.googleapis.com`: To inspect and update project IAM policies.

If `iam.googleapis.com` is disabled on the target Google Cloud project, deployments previously passed the `prepare` phase, uploaded source code to Cloud Storage, and failed asynchronously **2–3 minutes later inside Cloud Build** with an obscure error (`generic::permission_denied: Identity and Access Management (IAM) API is disabled`).

Rather than adding these APIs to `STANDARD_APIS` (which would auto-prompt enablement for all function deployments regardless of whether declarative security is used), this PR implements a lean fail-fast pre-flight check:

1. **Pre-Flight Validation (`checkDeclarativeSecurityApisEnabled`)**:
   - In `discoverSecurityDetails()`, checks that both `iam.googleapis.com` and `cloudresourcemanager.googleapis.com` are enabled on the project using `ensureApiEnabled.check()`.
   - If either API is disabled, aborts immediately in Phase 4 (`{ exit: 1 }`) before creating service accounts or packaging code.
   - Provides an actionable error message containing:
     - The exact, copy-pasteable CLI command: `gcloud services enable <apis> --project <projectId>`
     - Direct Google Cloud Console enablement URLs (via `ensureApiEnabled.enableApiURI(projectId, api)`) for users without `gcloud` or who need to forward the link to their project owner.

2. **Least-Privilege & CI/CD Safety (Fail-Open)**:
   - Catches errors during the Service Usage inspection check (e.g. if a restricted CI/CD deployment service account lacks `serviceusage.services.get`) and fails open with `logger.debug`. This ensures deployment-only credentials that lack Service Usage read access are not falsely blocked when the APIs are actually enabled.

3. **Guards & Unenrollment Safety**:
   - Standard functions (no `requiresRole`) bypass this check entirely.
   - Codebases unenrolling / opting out from declarative security (`!requiredRoles && existingManagedSA`) also bypass the check, ensuring users removing declarative security are never blocked.

---

### Scenarios Tested

- **Unit Tests (`src/deploy/functions/prepare.spec.ts`)**:
  - ✔ Both `iam.googleapis.com` and `cloudresourcemanager.googleapis.com` disabled: asserts unified error message, combined `gcloud` command, and console URLs.
  - ✔ Only `iam.googleapis.com` disabled: asserts single-API isolation.
  - ✔ Only `cloudresourcemanager.googleapis.com` disabled: asserts single-API isolation.
  - ✔ Non-declarative codebase: asserts API enablement checks are completely skipped.
  - ✔ Restricted caller permissions: asserts that a 403 on `serviceusage.services.get` fails open and does not block deployment.
  - ✔ Unenrollment from declarative security: asserts unenrollment succeeds even if security APIs are disabled.
  *(All 89 tests passing)*

---

### Sample Commands & Error Output

**When required APIs are disabled:**
```text
$ firebase deploy --only functions:firestore-bigquery-export

Error: Cannot deploy functions with declarative security in codebase "firestore-bigquery-export". The following required Google Cloud API(s) are not enabled on project my-project:
  - iam.googleapis.com

Declarative security requires these APIs to provision and configure managed service accounts and IAM roles.
To enable them, run:

  gcloud services enable iam.googleapis.com --project my-project

Or ask a project owner to enable them in the Google Cloud Console:
  - iam.googleapis.com: https://console.cloud.google.com/apis/library/iam.googleapis.com?project=my-project
