### PR TITLE
fix: prune secret versions labelled firebase-managed=functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
+- [fixed] Fixed `functions:secrets:set` and `functions:secrets:prune` never destroying unused secret versions.
 - [fixed] Clean up managed service accounts when opting out of declarative security alongside a filtered codebase deploy.

--- a/src/commands/functions-secrets-set.ts
+++ b/src/commands/functions-secrets-set.ts
@@ -31,8 +31,11 @@ export const command = new Command("functions:secrets:set <KEY>")
   .before(requirePermissions, [
     "secretmanager.secrets.create",
     "secretmanager.secrets.get",
+    "secretmanager.secrets.list",
     "secretmanager.secrets.update",
     "secretmanager.versions.add",
+    "secretmanager.versions.destroy",
+    "secretmanager.versions.list",
   ])
   .option(
     "--data-file <dataFile>",

--- a/src/functions/secrets.spec.ts
+++ b/src/functions/secrets.spec.ts
@@ -227,10 +227,11 @@ describe("functions/secret", () => {
     let listSecretVersionsStub: sinon.SinonStub;
     let getSecretVersionStub: sinon.SinonStub;
 
+    // Secrets created before v13.6.1 carry firebase-managed=true.
     const secret1: secretManager.Secret = {
       projectId: "project",
       name: "MY_SECRET1",
-      labels: {},
+      labels: { [secretManager.FIREBASE_MANAGED]: "true" },
       replication: {},
     };
     const secretVersion11: secretManager.SecretVersion = {
@@ -247,8 +248,34 @@ describe("functions/secret", () => {
     const secret2: secretManager.Secret = {
       projectId: "project",
       name: "MY_SECRET2",
+      labels: { [secretManager.FIREBASE_MANAGED]: "functions" },
+      replication: {},
+    };
+
+    const unmanagedSecret: secretManager.Secret = {
+      projectId: "project",
+      name: "UNMANAGED",
       labels: {},
       replication: {},
+    };
+
+    const apphostingSecret: secretManager.Secret = {
+      projectId: "project",
+      name: "APPHOSTING_SECRET",
+      labels: { [secretManager.FIREBASE_MANAGED]: "apphosting" },
+      replication: {},
+    };
+
+    const unmanagedVersion: secretManager.SecretVersion = {
+      secret: unmanagedSecret,
+      versionId: "1",
+      createTime: "2024-03-28T19:43:26",
+    };
+
+    const apphostingVersion: secretManager.SecretVersion = {
+      secret: apphostingSecret,
+      versionId: "1",
+      createTime: "2024-03-28T19:43:26",
     };
     const secretVersion21: secretManager.SecretVersion = {
       secret: secret2,
@@ -287,6 +314,30 @@ describe("functions/secret", () => {
       await expect(
         secrets.pruneSecrets({ projectId: "project", projectNumber: "12345" }, []),
       ).to.eventually.deep.equal([]);
+    });
+
+    it("finds secrets managed under either label value and ignores the rest", async () => {
+      listSecretsStub.resolves([secret1, secret2, unmanagedSecret, apphostingSecret]);
+      // Keyed by name rather than call order so an unmanaged secret slipping through
+      // shows up as an extra pruned version instead of an exhausted stub.
+      listSecretVersionsStub.withArgs("project", secret1.name).resolves([secretVersion11]);
+      listSecretVersionsStub.withArgs("project", secret2.name).resolves([secretVersion21]);
+      listSecretVersionsStub.withArgs("project", unmanagedSecret.name).resolves([unmanagedVersion]);
+      listSecretVersionsStub
+        .withArgs("project", apphostingSecret.name)
+        .resolves([apphostingVersion]);
+
+      const pruned = await secrets.pruneSecrets(
+        { projectId: "project", projectNumber: "12345" },
+        [],
+      );
+
+      expect(pruned).to.have.deep.members([secretVersion11, secretVersion21].map(toSecretEnvVar));
+      expect(pruned).to.have.length(2);
+      // Deep-equal the full argument list: calledWith would still pass if a stale
+      // label filter were being sent as a second argument.
+      expect(listSecretsStub.firstCall.args).to.deep.equal(["project"]);
+      expect(listSecretVersionsStub).to.have.callCount(2);
     });
 
     it("returns all secrets given no endpoints", async () => {

--- a/src/functions/secrets.ts
+++ b/src/functions/secrets.ts
@@ -237,8 +237,10 @@ export async function pruneSecrets(
   const pruneKey = (name: string, version: string) => `${name}@${version}`;
   const prunedSecrets: Set<string> = new Set();
 
-  // Collect all Firebase managed secret versions
-  const haveSecrets = await listSecrets(projectId, `labels.${FIREBASE_MANAGED}=true`);
+  // Collect all Firebase managed secret versions. Managed secrets carry either
+  // firebase-managed=true (older) or firebase-managed=functions, so match with
+  // isFunctionsManaged; a single-value server-side label filter misses one of them.
+  const haveSecrets = (await listSecrets(projectId)).filter(isFunctionsManaged);
   for (const secret of haveSecrets) {
     const versions = await listSecretVersions(projectId, secret.name, `NOT state: DESTROYED`);
     for (const version of versions) {


### PR DESCRIPTION
Fixes #11066.

### What was broken

`pruneSecrets` queried `labels.firebase-managed=true`, but `labels()` has written `firebase-managed=functions` since 13.6.1. The query matched nothing, so `functions:secrets:set` printed `Removing secret versions:` with an empty list and `functions:secrets:prune` reported `All secrets are in use` without examining anything. Every other call site uses `isFunctionsManaged`, which accepts both values.

### What changed

List without a label filter and select with `isFunctionsManaged`. That keeps one definition of "managed", still matches the older `=true` secrets, and excludes App Hosting secrets. The trade is listing all secrets in the project rather than a filtered page.

Second commit: `functions:secrets:set` now declares `secretmanager.secrets.list`, `versions.list` and `versions.destroy`. It has always performed those calls in its prune step, but they were unreachable while the query returned nothing, so a caller on a custom role would have hit a raw 403 after the redeploy rather than the upfront permission check.

### Verification

Unit tests cover both label values plus the unmanaged and App Hosting cases, and the new test fails against the old code.

Also exercised live against a real project with a deployed function using a secret. Rotating with `functions:secrets:set` destroyed the superseded versions and left the in-use one enabled; the same rotation on the unfixed build left them enabled. An App Hosting labelled secret, an unlabelled secret and an extensions-managed secret were all left alone.

### For the reviewer

This path has been dormant since 13.6.1, so the first run after this lands destroys the whole backlog at once, including versions that were deliberately disabled rather than destroyed (the version query is `NOT state: DESTROYED`). The `secrets:set` prompt says "destroy the stale version", singular, and `--force` skips it, so the list is only printed as it is destroyed. Restricting the version query to `state: ENABLED`, or naming the versions in the prompt, would both be reasonable; say which you prefer and I will add it.

`functions:secrets:prune` passes `default: true` to its confirm, and `guard()` returns the default in non-interactive mode, so in CI it destroys without a prompt and without `--force`. Worth deciding whether that should require an explicit flag before this change makes it reachable. Happy to add it here.
