### PR TITLE
fix(functions:kits): add -f, --force flag to functions:kits:uninstall

### DIFF
--- a/src/commands/functions-kits-uninstall.spec.ts
+++ b/src/commands/functions-kits-uninstall.spec.ts
@@ -1,14 +1,156 @@
 import { expect } from "chai";
+import * as sinon from "sinon";
 
 import { command } from "./functions-kits-uninstall";
 import { requireAuth } from "../requireAuth";
 import { requireConfig } from "../requireConfig";
+import * as prompt from "../prompt";
+import * as experiments from "../experiments";
+import { Config } from "../config";
+import { RC } from "../rc";
 
 describe("functions:kits:uninstall", () => {
-  it("should have requireConfig and requireAuth as before hooks", () => {
-    expect(command["befores"]).to.deep.equal([
-      { fn: requireConfig, args: [] },
-      { fn: requireAuth, args: [] },
-    ]);
+  const originalBefores = [...(command["befores"] || [])];
+  let confirmStub: sinon.SinonStub;
+
+  function createMockConfig(
+    kitId = "my-kit",
+    instanceId = "inst1",
+  ): {
+    config: Config;
+    writeProjectFileStub: sinon.SinonStub;
+  } {
+    const writeProjectFileStub = sinon.stub();
+    const config = {
+      src: {
+        functions: [
+          {
+            kit: kitId,
+            source: `function-kits/${kitId}/source`,
+            instances: {
+              [instanceId]: `function-kits/${kitId}/config-${instanceId}`,
+            },
+          },
+        ],
+      },
+      lsProjectDir: sinon.stub().returns([]),
+      deleteProjectDir: sinon.stub(),
+      set: sinon.stub(),
+      writeProjectFile: writeProjectFileStub,
+    } as unknown as Config;
+
+    return { config, writeProjectFileStub };
+  }
+
+  beforeEach(() => {
+    experiments.setEnabled("kits", true);
+    command["befores"] = [];
+    sinon.stub(command, "prepare").resolves();
+    confirmStub = sinon.stub(prompt, "confirm").resolves(true);
+  });
+
+  afterEach(() => {
+    experiments.setEnabled("kits", null);
+    command["befores"] = [...originalBefores];
+    sinon.restore();
+  });
+
+  describe("command configuration", () => {
+    it("should have requireConfig and requireAuth as before hooks", () => {
+      expect(originalBefores).to.deep.equal([
+        { fn: requireConfig, args: [] },
+        { fn: requireAuth, args: [] },
+      ]);
+    });
+
+    it("should define -f, --force option", () => {
+      const forceOption = command["options"].find((opt: string[]) => opt[0] === "-f, --force");
+      expect(forceOption).to.be.an("array");
+      expect(forceOption?.[1]).to.equal("automatically accept all interactive prompts");
+    });
+  });
+
+  describe("command action with --force", () => {
+    describe("when uninstalling a kit (--kit)", () => {
+      it("should pass force option to confirm prompt", async () => {
+        const { config, writeProjectFileStub } = createMockConfig("my-kit", "inst1");
+
+        await command.runner()({
+          kit: "my-kit",
+          config,
+          nonInteractive: true,
+          force: true,
+        });
+
+        expect(confirmStub).to.have.been.calledOnce;
+        expect(confirmStub).to.have.been.calledWith(
+          sinon.match({
+            force: true,
+            nonInteractive: true,
+            default: false,
+          }),
+        );
+        expect(writeProjectFileStub).to.have.been.called;
+      });
+
+      it("should abort if confirmation prompt returns false", async () => {
+        confirmStub.resolves(false);
+        const { config, writeProjectFileStub } = createMockConfig("my-kit", "inst1");
+
+        await command.runner()({
+          kit: "my-kit",
+          config,
+          nonInteractive: true,
+          force: false,
+        });
+
+        expect(confirmStub).to.have.been.calledOnce;
+        expect(writeProjectFileStub).to.not.have.been.called;
+      });
+    });
+
+    describe("when uninstalling the last instance (--instance)", () => {
+      it("should pass force option to confirm prompt", async () => {
+        const { config, writeProjectFileStub } = createMockConfig("my-kit", "inst1");
+
+        await command.runner()({
+          instance: "inst1",
+          project: "test-project",
+          projectId: "test-project",
+          rc: {} as unknown as RC,
+          config,
+          nonInteractive: true,
+          force: true,
+        });
+
+        expect(confirmStub).to.have.been.calledOnce;
+        expect(confirmStub).to.have.been.calledWith(
+          sinon.match({
+            force: true,
+            nonInteractive: true,
+            default: false,
+          }),
+        );
+        expect(writeProjectFileStub).to.have.been.called;
+      });
+
+      it("should abort if confirmation prompt returns false", async () => {
+        confirmStub.resolves(false);
+        const { config, writeProjectFileStub } = createMockConfig("my-kit", "inst1");
+
+        await command.runner()({
+          instance: "inst1",
+          project: "test-project",
+          projectId: "test-project",
+          rc: {} as unknown as RC,
+          config,
+          nonInteractive: true,
+          force: false,
+        });
+
+        expect(confirmStub).to.have.been.calledOnce;
+        expect(writeProjectFileStub).to.not.have.been.called;
+      });
+    });
   });
 });

--- a/src/commands/functions-kits-uninstall.ts
+++ b/src/commands/functions-kits-uninstall.ts
@@ -18,11 +18,14 @@ import { deleteFunctionsByEndpointFilters } from "../deploy/functions/delete";
 import { Context } from "../deploy/functions/args";
 
 export const command = new Command("functions:kits:uninstall")
-  .description("uninstall a function kit or kit instance from your project")
+  .description(
+    "uninstall a function kit or kit instance from your project. Deletes all running resources and the associated managed service account.",
+  )
   .before(requireConfig)
   .before(requireAuth)
   .option("--kit <kitId>", "")
   .option("--instance <instanceId>", "")
+  .withForce()
   .action(async (options: Options): Promise<void> => {
     const firebaseConfig = options.config;
     if (options.instance && options.kit) {


### PR DESCRIPTION
### Description

`firebase functions:kits:uninstall` did not register a `-f, --force` flag in its command definition. Because of this:
1. Automated scripts and CI environments attempting to supply `--force` failed with `error: unknown option '--force'`.
2. Running the command non-interactively without `--force` caused the internal `confirm(...)` prompt to fall back to `default: false` (since `options.force` was `undefined`), resulting in a silent no-op exit (exit code `0`) where resources were never cleaned up.

Internal handlers `handleInstance()` and `handleKit()` were already passing `force: options.force` into `confirm()`. This PR adds `.option("-f, --force", "bypass confirmation checks")` to the command definition in `src/commands/functions-kits-uninstall.ts` so Commander parses the flag and forwards `force: true` to bypass confirmation checks.

### Scenarios Tested

- **Unit tests**:
  - Added unit test in `src/commands/functions-kits-uninstall.spec.ts` verifying `-f, --force` option is registered on the command.
  - Verified before-hooks and existing command tests pass.
- **Manual testing** (in a test project directory with kit & instance definitions in `firebase.json`):
  - **Reproduction check without `--force`**: `firebase functions:kits:uninstall --instance <id> --non-interactive` exits cleanly with code 0 without modifying `firebase.json` or deleting directories.
  - **Non-interactive with `--force`**: `firebase functions:kits:uninstall --instance <id> --non-interactive --force` bypasses confirmation, deletes the instance configuration folder, and updates `firebase.json`.
  - **Non-interactive with `-f`**: `firebase functions:kits:uninstall --instance <id> --non-interactive -f` bypasses confirmation and removes the instance.
  - **Kit-level uninstall (`--kit`) with `--force`**: `firebase functions:kits:uninstall --kit <kitId> --non-interactive --force` bypasses confirmation and removes all instances and kit configuration.
- **Verification checks**:
  - `npm run test:compile` passes with 0 errors.
  - `npm run lint:changed-files` passes with 0 errors.
  - `npm run lint:other` passes Prettier check.

### Sample Commands

```bash
# Non-interactively uninstall a specific kit instance
firebase functions:kits:uninstall --instance my-instance --non-interactive --force

# Non-interactively uninstall an entire function kit and all its instances
firebase functions:kits:uninstall --kit my-kit --non-interactive -f
