### PR TITLE
fix(functions): add skipLibCheck to functions typescript template

### DIFF
--- a/src/functions/kits/install.spec.ts
+++ b/src/functions/kits/install.spec.ts
@@ -3151,6 +3151,11 @@ describe("functions/kits/install", () => {
           },
         ],
       });
+
+      const tsconfig = JSON.parse(
+        writtenFiles["function-kits/firestore-bigquery-export/source/tsconfig.json"] as string,
+      ) as { compilerOptions?: { skipLibCheck?: boolean } };
+      expect(tsconfig.compilerOptions?.skipLibCheck).to.be.true;
     });
 
     it("should accept custom kitId and instanceId for package kit", async () => {

--- a/templates/init/functions/typescript/tsconfig.json
+++ b/templates/init/functions/typescript/tsconfig.json
@@ -9,7 +9,8 @@
     "rootDir": "src",
     "sourceMap": true,
     "strict": true,
-    "target": "es2017"
+    "target": "es2017",
+    "skipLibCheck": true
   },
   "compileOnSave": true,
   "include": [


### PR DESCRIPTION
### Description

Function kit wrappers scaffolded by `functions:kits:install` inherit their `tsconfig.json` from `templates/init/functions/typescript/tsconfig.json`. When installing kits that depend on modern packages with optional peer dependencies or ambient typings (such as `@firebase-function-kits/firestore-genai-chatbot`, which pulls in `@google/genai` referencing `@modelcontextprotocol/sdk` and `dotprompt` referencing `handlebars`), `npm run build` (`tsc`) fails during installation because TypeScript attempts to type-check third-party declaration files inside `node_modules`.

This change adds `"skipLibCheck": true` to `templates/init/functions/typescript/tsconfig.json` (consistent with `templates/extensions/typescript/tsconfig.json` and `firebase init genkit`).

### Scenarios Tested

- **Unit tests**: Added an assertion in `src/functions/kits/install.spec.ts` ensuring that installed kit wrappers include `skipLibCheck: true` in `tsconfig.json`. Ran `npx mocha src/functions/kits/install.spec.ts` (156 passing, 0 failing).
- **Linter**: `npm run lint:changed-files` passed with 0 errors.
- **End-to-End Test**: Tested installing `@firebase-function-kits/firestore-genai-chatbot@next` via `firebase functions:kits:install --package @firebase-function-kits/firestore-genai-chatbot@next --no-configure` using the built CLI. Verified that `tsconfig.json` is generated with `"skipLibCheck": true` and `tsc` compiles with 0 errors, successfully completing installation.

### Sample Commands

```bash
firebase functions:kits:install --package @firebase-function-kits/firestore-genai-chatbot@next
