### PR TITLE
add a confirmable extension version update flow to ext:export

### DIFF
--- a/src/commands/ext-export.ts
+++ b/src/commands/ext-export.ts
@@ -30,6 +30,7 @@ import { Config } from "../config";
 import { normalizeAndValidate, isKitConfig } from "../functions/projectConfig";
 import { FirebaseError } from "../error";
 import * as experiments from "../experiments";
+import { ensureInstanceUpToDate } from "../extensions/migrate";
 
 export const command = new Command("ext:export")
   .description("export Extension instances installed on a project to a local Firebase directory")
@@ -152,7 +153,7 @@ async function fnHandler(options: Options): Promise<void> {
     return;
   }
   const projectId = needProjectId(options);
-  const instance = await getInstance(projectId, options.instance as string);
+  let instance = await getInstance(projectId, options.instance as string);
   if (typeof instance === "undefined") {
     logger.info(`No extension matching instance ID ${options.instance} found`);
     return;
@@ -162,6 +163,11 @@ async function fnHandler(options: Options): Promise<void> {
       `Extension ${options.instance} is in state ${instance.state}. To export a non-ACTIVE extension, use the --force option.`,
     );
   }
+  instance = await ensureInstanceUpToDate(projectId, instance, {
+    nonInteractive: options.nonInteractive,
+    force: options.force,
+    confirmBeforeUpdate: true,
+  });
 
   const instanceId = last(instance.name.split("/")) ?? "";
   if (instanceId !== options.instance) {

--- a/src/extensions/migrate.ts
+++ b/src/extensions/migrate.ts
@@ -26,6 +26,7 @@ export interface MigrateOptions {
   package?: string;
   extInstance?: string;
   extension?: string;
+  confirmBeforeUpdate?: boolean;
   nonInteractive?: boolean;
   force?: boolean;
 }
@@ -375,10 +376,30 @@ export async function ensureInstanceUpToDate(
     return instance;
   }
 
-  logLabeledBullet(
-    logPrefix,
-    `Upgrading extension instance ${clc.bold(instanceId)} from version ${clc.bold(currentVersion)} to ${clc.bold(latestVersion)} to ensure a smooth migration...`,
-  );
+  if (options?.confirmBeforeUpdate) {
+    const allowUpdate = await confirm({
+      message: `Extension update available: ${clc.bold(currentVersion)} to ${clc.bold(latestVersion)}. Update ${clc.bold(instanceId)}?`,
+      default: true,
+      nonInteractive: options?.nonInteractive,
+    });
+    if (!allowUpdate) {
+      if (options.force) {
+        logLabeledWarning(
+          logPrefix,
+          "Migrating an out-of-date Extension instance into a functions kit could result in instability.",
+        );
+        return instance;
+      }
+      throw new FirebaseError(
+        "Migrating an out-of-date Extension instance into a functions kit could result in instability. Run with --force if you're sure you want to do this.",
+      );
+    }
+  } else {
+    logLabeledBullet(
+      logPrefix,
+      `Upgrading extension instance ${clc.bold(instanceId)} from version ${clc.bold(currentVersion)} to ${clc.bold(latestVersion)} to ensure a smooth migration...`,
+    );
+  }
 
   const targetRef = `${baseRef}@${latestVersion}`;
   let finalParams: Record<string, string> = {


### PR DESCRIPTION
Sure do love it when Thomas does all of the actual hard work for me.

Seems intuitive fair to me that the guided ext:migrate flow would always want to update extension version while asking, while ext:export would want to give users a choice. Let me know if you disagree.