### PR TITLE
ext:uninstall improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - [fixed] Clean up managed service accounts when opting out of declarative security alongside a filtered codebase deploy.
+- ext:uninstall --immediate now warns about secrets bound to the extension that will be deleted and offers a migration path.

--- a/src/commands/ext-uninstall.ts
+++ b/src/commands/ext-uninstall.ts
@@ -11,6 +11,11 @@ import * as manifest from "../extensions/manifest";
 import { Options } from "../options";
 import { needProjectId } from "../projectUtils";
 import { uninstallExtension } from "../extensions/migrate";
+import { getInstance } from "../extensions/extensionsApi";
+import { secretsNeedingEjection } from "../extensions/export";
+import { FirebaseError } from "../error";
+import { ExtensionInstance } from "../extensions/types";
+import { confirm } from "../prompt";
 
 export const command = new Command("ext:uninstall <extensionInstanceId>")
   .description("uninstall an extension that is installed in your Firebase project by instance ID")
@@ -33,6 +38,36 @@ export const command = new Command("ext:uninstall <extensionInstanceId>")
     }
     if (options.immediate) {
       const projectId = needProjectId(options);
+      let instance: ExtensionInstance | undefined;
+      try {
+        instance = await getInstance(projectId, instanceId);
+      } catch (err: unknown) {
+        if (err instanceof FirebaseError && err.status === 404) {
+          logLabeledWarning(
+            logPrefix,
+            "ext:uninstall called with --immediate, but no deployed GCP resources found for the extension.",
+          );
+          return;
+        }
+        throw err instanceof FirebaseError ? err : new FirebaseError(String(err));
+      }
+      if (typeof instance === "undefined") {
+        throw new FirebaseError(
+          `Failed to retrieve deployed GCP resources for extension instance ${instanceId}`,
+        );
+      }
+      const outstandingSecrets = await secretsNeedingEjection(instance);
+      if (outstandingSecrets.length > 0) {
+        const shouldContinue = await confirm({
+          message: `Extension instance ${instanceId} has secrets with the "firebase-extensions-managed" label:\n${outstandingSecrets.join(", ")}\nContinuing with extension uninstall will permanantly destroy these secrets.\nYou can keep these secrets by running ext:export, or by manually removing the label in the Cloud Console.\nContinue? (y/N)`,
+          default: false,
+          nonInteractive: options.nonInteractive,
+          force: options.force,
+        });
+        if (!shouldContinue) {
+          return;
+        }
+      }
       await uninstallExtension(projectId, instanceId, options, false);
       return;
     }

--- a/src/commands/ext-uninstall.ts
+++ b/src/commands/ext-uninstall.ts
@@ -23,7 +23,7 @@ export const command = new Command("ext:uninstall <extensionInstanceId>")
   .option("--local", "deprecated")
   .option(
     "--immediate",
-    "immediately destroy GCP resources instead of waiting on next deploy. Can be run outside a firebase project directory.",
+    "immediately destroy GCP resources instead of waiting on next deploy. Can be run outside a firebase project directory if --project is specified.",
   )
   .withForce()
   .before(requirePermissions, ["firebaseextensions.instances.delete"])
@@ -50,6 +50,7 @@ export const command = new Command("ext:uninstall <extensionInstanceId>")
           );
           const config = manifest.loadConfig(options);
           manifest.removeFromManifest(instanceId, config);
+          return;
         }
         throw new FirebaseError(
           `Failed to retrieve extension instance ${instanceId}: ${err instanceof Error ? err.message : String(err)}`,
@@ -72,6 +73,11 @@ export const command = new Command("ext:uninstall <extensionInstanceId>")
           force: options.force,
         });
         if (!shouldContinue) {
+          if (options.nonInteractive && !options.force) {
+            throw new FirebaseError(
+              `Extension instance ${instanceId} has managed secrets that would be permanently destroyed. Re-run with --force in non-interactive mode to confirm deletion.`,
+            );
+          }
           return;
         }
       }

--- a/src/commands/ext-uninstall.ts
+++ b/src/commands/ext-uninstall.ts
@@ -4,6 +4,7 @@ import {
   ensureExtensionsApiEnabled,
   diagnoseAndFixProject,
   logPrefix,
+  ensureInstanceSpec,
 } from "../extensions/extensionsHelper";
 import { requirePermissions } from "../requirePermissions";
 import { logLabeledWarning } from "../utils";
@@ -47,19 +48,25 @@ export const command = new Command("ext:uninstall <extensionInstanceId>")
             logPrefix,
             "ext:uninstall called with --immediate, but no deployed GCP resources found for the extension.",
           );
-          return;
+          const config = manifest.loadConfig(options);
+          manifest.removeFromManifest(instanceId, config);
         }
-        throw err instanceof FirebaseError ? err : new FirebaseError(String(err));
-      }
-      if (typeof instance === "undefined") {
         throw new FirebaseError(
-          `Failed to retrieve deployed GCP resources for extension instance ${instanceId}`,
+          `Failed to retrieve extension instance ${instanceId}: ${err instanceof Error ? err.message : String(err)}`,
+          {
+            original: err instanceof Error ? err : undefined,
+            exit: 1,
+          },
         );
       }
+      if (!instance) {
+        throw new FirebaseError(`Failed to retrieve extension instance ${instanceId}`);
+      }
+      instance = await ensureInstanceSpec(instance);
       const outstandingSecrets = await secretsNeedingEjection(instance);
       if (outstandingSecrets.length > 0) {
         const shouldContinue = await confirm({
-          message: `Extension instance ${instanceId} has secrets with the "firebase-extensions-managed" label:\n${outstandingSecrets.join(", ")}\nContinuing with extension uninstall will permanantly destroy these secrets.\nYou can keep these secrets by running ext:export, or by manually removing the label in the Cloud Console.\nContinue? (y/N)`,
+          message: `Extension instance ${instanceId} has secrets with the "firebase-extensions-managed" label:\n${outstandingSecrets.join(", ")}\nContinuing with extension uninstall will permanently destroy these secrets.\nYou can keep these secrets by running ext:export, or by manually removing the label in the Cloud Console.\nContinue?`,
           default: false,
           nonInteractive: options.nonInteractive,
           force: options.force,


### PR DESCRIPTION
First, ext:uninstall --immediate didn't check if there was any deployed ExtensionInstance to actually immediately destroy, which would result in deleting from firebase.json but then spitting out an error message anyway when the DeleteInstance call failed.

Second, ext:uninstall --immediate should warn if it thinks that it's about to permanently destroy unmigrated secrets. This could be user intent, since not all users will want to migrate to kits, so we won't demand --force or anything to progress past the warning.