### PR TITLE
call ensureInstanceUpToDate in ext:export

### DIFF
--- a/src/commands/ext-export.ts
+++ b/src/commands/ext-export.ts
@@ -10,7 +10,7 @@ import {
   ejectSecretsFromInstance,
   secretsNeedingEjection,
 } from "../extensions/export";
-import { ensureExtensionsApiEnabled } from "../extensions/extensionsHelper";
+import { ensureExtensionsApiEnabled, ensureInstanceSpec } from "../extensions/extensionsHelper";
 import * as manifest from "../extensions/manifest";
 import { buildBindingOptionsWithBaseValue } from "../extensions/paramHelper";
 import { partition } from "../functional";
@@ -161,6 +161,12 @@ async function fnHandler(options: Options): Promise<void> {
   if (instance.state !== "ACTIVE" && !options.force) {
     throw new FirebaseError(
       `Extension ${options.instance} is in state ${instance.state}. To export a non-ACTIVE extension, use the --force option.`,
+    );
+  }
+  instance = await ensureInstanceSpec(instance);
+  if (!instance.config?.source?.spec) {
+    throw new FirebaseError(
+      `Could not load extension specification for ${options.instance}. Unable to export configuration.`,
     );
   }
   instance = await ensureInstanceUpToDate(projectId, instance, {

--- a/src/commands/ext-export.ts
+++ b/src/commands/ext-export.ts
@@ -30,6 +30,7 @@ import { Config } from "../config";
 import { normalizeAndValidate, isKitConfig } from "../functions/projectConfig";
 import { FirebaseError } from "../error";
 import * as experiments from "../experiments";
+import { ensureInstanceUpToDate } from "../extensions/migrate";
 
 export const command = new Command("ext:export")
   .description("export Extension instances installed on a project to a local Firebase directory")
@@ -152,7 +153,7 @@ async function fnHandler(options: Options): Promise<void> {
     return;
   }
   const projectId = needProjectId(options);
-  const instance = await getInstance(projectId, options.instance as string);
+  let instance = await getInstance(projectId, options.instance as string);
   if (typeof instance === "undefined") {
     logger.info(`No extension matching instance ID ${options.instance} found`);
     return;
@@ -162,6 +163,10 @@ async function fnHandler(options: Options): Promise<void> {
       `Extension ${options.instance} is in state ${instance.state}. To export a non-ACTIVE extension, use the --force option.`,
     );
   }
+  instance = await ensureInstanceUpToDate(projectId, instance, {
+    nonInteractive: options.nonInteractive,
+    force: options.force,
+  });
 
   const instanceId = last(instance.name.split("/")) ?? "";
   if (instanceId !== options.instance) {


### PR DESCRIPTION
Dumb question: is ensureInstanceUpToDate the correct name now that it doesn't, well, ensure that the instance is up to date if the user refuses permission to upgrade?