### PR TITLE
Update Pub/Sub emulator to v0.8.36 to resolve CVE-2026-75595

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
+- Updated Pub/Sub emulator to version 0.8.36.
 - [fixed] Clean up managed service accounts when opting out of declarative security alongside a filtered codebase deploy.

--- a/src/emulator/downloadableEmulatorInfo.json
+++ b/src/emulator/downloadableEmulatorInfo.json
@@ -44,13 +44,13 @@
     }
   },
   "pubsub": {
-    "version": "0.8.35",
-    "expectedSize": 53015972,
-    "expectedChecksum": "04cb782e3edf7a2b117990af8506453e",
-    "expectedChecksumSHA256": "b0f3b73a14b716ecf8925b7b8a0c8c858ffabddcf03df8b2b7fba682f48dc616",
-    "remoteUrl": "https://storage.googleapis.com/firebase-preview-drop/emulator/pubsub-emulator-0.8.35.zip",
-    "downloadPathRelativeToCacheDir": "pubsub-emulator-0.8.35.zip",
-    "binaryPathRelativeToCacheDir": "pubsub-emulator-0.8.35/pubsub-emulator/bin/cloud-pubsub-emulator"
+    "version": "0.8.36",
+    "expectedSize": 53026271,
+    "expectedChecksum": "f62d997f52619f4800f34f42136178ef",
+    "expectedChecksumSHA256": "0b3a030b3a92aba50082aeed7ee63008a45b032b7231090d3a1bcd8744e0e2e5",
+    "remoteUrl": "https://storage.googleapis.com/firebase-preview-drop/emulator/pubsub-emulator-0.8.36.zip",
+    "downloadPathRelativeToCacheDir": "pubsub-emulator-0.8.36.zip",
+    "binaryPathRelativeToCacheDir": "pubsub-emulator-0.8.36/pubsub-emulator/bin/cloud-pubsub-emulator"
   },
   "dataconnect": {
     "darwin": {


### PR DESCRIPTION
Updates the Pub/Sub emulator to version 0.8.36, which updates netty to version 4.1.137.Final, resolving CVE-2026-75595.