### PR TITLE
fix(functions): remove salt from declarative security etag label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 - Updated Pub/Sub emulator to version 0.8.36.
 - [fixed] Clean up managed service accounts when opting out of declarative security alongside a filtered codebase deploy.
 - ext:uninstall --immediate now warns about secrets bound to the extension that will be deleted and offers a migration path.
+- [fixed] Generate deterministic unsalted ETags for declarative security roles.

--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -1514,6 +1514,30 @@ describe("prepare", () => {
       expect(e.labels?.["firebase-declarative-security-etag"]).to.equal(result.newEtag);
     });
 
+    it("should skip permission checks when haveRolesEtag matches newEtag", async () => {
+      const etag = iam.computeRolesEtag(["roles/viewer"]);
+      const e: backend.Endpoint = {
+        ...ENDPOINT,
+        serviceAccount: "firebase-fn-123@project.iam.gserviceaccount.com",
+        labels: {
+          "firebase-declarative-security-etag": etag,
+        },
+      };
+      const want = backend.of(e);
+      want.requiredRoles = ["roles/viewer"];
+      const have = backend.of({
+        ...e,
+        labels: { ...e.labels },
+      });
+
+      testIamPermissionsStub.rejects(new Error("Should not be called"));
+      const result = await prepare.discoverSecurityDetails("default", want, have, "project");
+
+      expect(result.haveRolesEtag).to.equal(etag);
+      expect(result.newEtag).to.equal(etag);
+      expect(testIamPermissionsStub).to.not.have.been.called;
+    });
+
     it("should reset endpoints to default service account when unenrolling (opting out)", async () => {
       const e: backend.Endpoint = {
         ...ENDPOINT,

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -168,8 +168,7 @@ export async function discoverSecurityDetails(
     managedSA = `${saToCreate}@${projectId}.iam.gserviceaccount.com`;
   }
 
-  const existingSalt = haveRolesEtag ? haveRolesEtag.split("-")[0] : undefined;
-  const newEtag = iam.computeRolesEtag(requiredRoles!, existingSalt);
+  const newEtag = iam.computeRolesEtag(requiredRoles!);
 
   for (const endpoint of backend.allEndpoints(want)) {
     endpoint.serviceAccount = managedSA;

--- a/src/gcp/iam.spec.ts
+++ b/src/gcp/iam.spec.ts
@@ -278,5 +278,31 @@ describe("iam", () => {
         expect(nock.isDone()).to.be.true;
       });
     });
+
+    describe("computeRolesEtag", () => {
+      it("should return a 32-character base38 hash starting with [a-z]", () => {
+        const etag = iam.computeRolesEtag(["roles/viewer"]);
+        expect(etag).to.have.lengthOf(32);
+        expect(etag).to.match(/^[a-z][a-z0-9_-]{31}$/);
+      });
+
+      it("should be deterministic regardless of role order", () => {
+        const etag1 = iam.computeRolesEtag(["roles/viewer", "roles/editor"]);
+        const etag2 = iam.computeRolesEtag(["roles/editor", "roles/viewer"]);
+        expect(etag1).to.equal(etag2);
+      });
+
+      it("should be deterministic regardless of duplicate roles", () => {
+        const etag1 = iam.computeRolesEtag(["roles/viewer"]);
+        const etag2 = iam.computeRolesEtag(["roles/viewer", "roles/viewer"]);
+        expect(etag1).to.equal(etag2);
+      });
+
+      it("should produce different etags for different role sets", () => {
+        const etag1 = iam.computeRolesEtag(["roles/viewer"]);
+        const etag2 = iam.computeRolesEtag(["roles/editor"]);
+        expect(etag1).to.not.equal(etag2);
+      });
+    });
   });
 });

--- a/src/gcp/iam.ts
+++ b/src/gcp/iam.ts
@@ -329,24 +329,15 @@ export async function generateManagedServiceAccountName(
   throw new FirebaseError("Failed to generate a unique service account name after 10 attempts.");
 }
 
-/** Computes a base38 label etag formatted as <random 10 char salt>-<base38 hash>. */
-export function computeRolesEtag(roles: string[], existingSalt?: string): string {
+/** Computes a deterministic base38 label etag from required roles, starting with [a-z]. */
+export function computeRolesEtag(roles: string[]): string {
+  const ALPHA_CHARS = "abcdefghijklmnopqrstuvwxyz";
   const BASE38_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_";
-  let salt = existingSalt;
-  if (!salt) {
-    salt = String.fromCharCode(97 + Math.floor(Math.random() * 26)); // a-z
-    for (let i = 0; i < 9; i++) {
-      salt += BASE38_CHARS[Math.floor(Math.random() * 38)];
-    }
+  const sorted = Array.from(new Set(roles)).sort();
+  const hashBuffer = crypto.createHash("sha256").update(sorted.join(",")).digest();
+  let hashStr = ALPHA_CHARS[hashBuffer[0] % ALPHA_CHARS.length];
+  for (let i = 1; i < hashBuffer.length; i++) {
+    hashStr += BASE38_CHARS[hashBuffer[i] % BASE38_CHARS.length];
   }
-  const sorted = Array.from(roles).sort();
-  const hashBuffer = crypto
-    .createHash("sha256")
-    .update(salt + sorted.join(","))
-    .digest();
-  let hashStr = "";
-  for (const byte of hashBuffer) {
-    hashStr += BASE38_CHARS[byte % 38];
-  }
-  return `${salt}-${hashStr.substring(0, 52)}`;
+  return hashStr;
 }


### PR DESCRIPTION
### Description

Removes the random salt from declarative security role ETag generation in favor of a deterministic 32-character hash starting with an alpha character. This eliminates delimiter parsing collisions on subsequent deployments, guarantees compatibility with GCP resource label constraints, and allows reliable fast-path deployment checks without salt recovery.

### Scenarios Tested

- Ran `npm test`.
- Added unit tests in `src/gcp/iam.spec.ts` verifying `computeRolesEtag` produces valid 32-character labels (`/^[a-z][a-z0-9_-]{31}$/`), ensures determinism regardless of role order, and differentiates distinct role sets.
- Added unit test in `src/deploy/functions/prepare.spec.ts` verifying deployments with matching ETags skip IAM permission checks (fast path).
- Manually tested deployment with `firebase deploy --only functions`.

### Sample Commands

- `firebase deploy --only functions`
