### PR TITLE
env reserved prefix handling

### DIFF
--- a/src/extensions/export.ts
+++ b/src/extensions/export.ts
@@ -231,6 +231,8 @@ export function functionsEnvFromInstance(instance: ExtensionInstance): Record<st
   }
 
   // Also pull in ALLOWED_EVENTS and EVENTARC_CHANNEL
+  // The Extensions backend was translating ALLOWED_EVENTS into process.env.EXT_SELECTED_EVENTS,
+  // so a kits environment has to duplicate that behavior.
   if (typeof instance.config.allowedEventTypes !== "undefined") {
     envs["EXT_SELECTED_EVENTS"] = instance.config.allowedEventTypes.toString();
   }

--- a/src/functions/env.spec.ts
+++ b/src/functions/env.spec.ts
@@ -301,10 +301,10 @@ FOO=foo
         }).to.not.throw();
         expect(() => {
           env.validateKey("EXT_SELECTED_EVENTS_");
-        }).to.throw("unexpected suffix");
+        }).to.throw("conflicts with known key");
         expect(() => {
           env.validateKey("EXT_SELECTED_EVENTS_FOO");
-        }).to.throw("unexpected suffix");
+        }).to.throw("conflicts with known key");
       });
     });
   });

--- a/src/functions/env.spec.ts
+++ b/src/functions/env.spec.ts
@@ -295,7 +295,16 @@ FOO=foo
         }).to.not.throw();
         expect(() => {
           env.validateKey("FIREBASE_SECRET_REF_");
-        }).to.throw("empty suffix");
+        }).to.throw("requires a suffix");
+        expect(() => {
+          env.validateKey("EXT_SELECTED_EVENTS");
+        }).to.not.throw();
+        expect(() => {
+          env.validateKey("EXT_SELECTED_EVENTS_");
+        }).to.throw("unexpected suffix");
+        expect(() => {
+          env.validateKey("EXT_SELECTED_EVENTS_FOO");
+        }).to.throw("unexpected suffix");
       });
     });
   });

--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -10,6 +10,10 @@ import { logBullet, logWarning } from "../utils";
 const FUNCTIONS_EMULATOR_DOTENV = ".env.local";
 
 const RESERVED_PREFIXES = ["X_GOOGLE_", "FIREBASE_", "EXT_", "KIT_"];
+// Keys beginning with these prefixes are not rejected for violating RESERVED_PREFIXES.
+// If a key ends with _, it is an error for there to be no suffix; if a key does not
+// end with _, it is an error for there to be a suffix.
+// For example, "FIREBASE_SECRET_REF_" and "EXT_SELECTED_EVENTS_FOO" will both throw.
 const RESERVED_PREFIX_ALLOWLIST = [
   "FIREBASE_SECRET_REF_",
   "EXT_MIGRATED_SYSTEM_",
@@ -187,19 +191,35 @@ export function validateKey(key: string): void {
       `Key ${key} starts with a reserved prefix (${RESERVED_PREFIXES.join(" ")})`,
     );
   }
-  if (RESERVED_PREFIX_ALLOWLIST.some((prefix) => key === prefix)) {
-    throw new KeyValidationError(key, `Key ${key} is a known prefix with an empty suffix`);
-  }
 }
 
 /**
- * @return true if the key begins with a prefix on the reserved list and is not a known usage.
+ * Returns true if the key begins with a prefix on the reserved list and is not a known allowlisted usage.
+ * Returns false if the key does not begin with a prefix on the reserved list
+ * Throws if the key is a known allowlisted usage but is malformed:
+ * For example, "FIREBASE_SECRET_REF_" and "EXT_SELECTED_EVENTS_FOO" will both throw.
  */
 function keyConflictsWithReservedPrefixes(key: string): boolean {
   return RESERVED_PREFIXES.some(
     (prefix) =>
-      key.startsWith(prefix) && !RESERVED_PREFIX_ALLOWLIST.some((known) => key.startsWith(known)),
+      key.startsWith(prefix) &&
+      !RESERVED_PREFIX_ALLOWLIST.some((allowedPrefix) =>
+        keyPermittedByKnownPrefix(key, allowedPrefix),
+      ),
   );
+}
+
+function keyPermittedByKnownPrefix(key: string, prefix: string): boolean {
+  if (!key.startsWith(prefix)) {
+    return false;
+  }
+  if (prefix.endsWith("_") && key === prefix) {
+    throw new KeyValidationError(key, `Key ${key} is a known prefix that requires a suffix`);
+  }
+  if (!prefix.endsWith("_") && key !== prefix) {
+    throw new KeyValidationError(key, `Key ${key} is a known prefix with an unexpected suffix`);
+  }
+  return true;
 }
 
 /**

--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -10,9 +10,9 @@ import { logBullet, logWarning } from "../utils";
 const FUNCTIONS_EMULATOR_DOTENV = ".env.local";
 
 const RESERVED_PREFIXES = ["X_GOOGLE_", "FIREBASE_", "EXT_", "KIT_"];
-// Keys beginning with these prefixes are not rejected for violating RESERVED_PREFIXES.
-// If a key ends with _, it is an error for there to be no suffix; if a key does not
-// end with _, it is an error for there to be a suffix.
+// Allow list for keys & key prefixes within the reserved prefixes that should not be rejected for violating RESERVED_PREFIXES.
+// If an allow list entry ends with _, it is a prefix and it is an error for there to be no suffix in the key.
+// If an allow list entry does not end with _, it is a whole key and it is an error for there to be a suffix in the key.
 // For example, "FIREBASE_SECRET_REF_" and "EXT_SELECTED_EVENTS_FOO" will both throw.
 const RESERVED_PREFIX_ALLOWLIST = [
   "FIREBASE_SECRET_REF_",
@@ -219,7 +219,10 @@ function keyPermittedByKnownPrefix(key: string, prefix: string): boolean {
     throw new KeyValidationError(key, `Key ${key} is a known prefix that requires a suffix`);
   }
   if (!prefix.endsWith("_") && key !== prefix) {
-    throw new KeyValidationError(key, `Key ${key} is a known prefix with an unexpected suffix`);
+    throw new KeyValidationError(
+      key,
+      `Key ${key} conflicts with known key ${prefix} that does not permit a suffix`,
+    );
   }
   return true;
 }

--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -200,13 +200,15 @@ export function validateKey(key: string): void {
  * For example, "FIREBASE_SECRET_REF_" and "EXT_SELECTED_EVENTS_FOO" will both throw.
  */
 function keyConflictsWithReservedPrefixes(key: string): boolean {
-  return RESERVED_PREFIXES.some(
-    (prefix) =>
-      key.startsWith(prefix) &&
-      !RESERVED_PREFIX_ALLOWLIST.some((allowedPrefix) =>
-        keyPermittedByKnownPrefix(key, allowedPrefix),
-      ),
-  );
+  if (!RESERVED_PREFIXES.some((prefix) => key.startsWith(prefix))) {
+    return false;
+  }
+  for (const allowedPrefix of RESERVED_PREFIX_ALLOWLIST) {
+    if (keyPermittedByKnownPrefix(key, allowedPrefix)) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function keyPermittedByKnownPrefix(key: string, prefix: string): boolean {


### PR DESCRIPTION
The EXT_SELECTED_EVENTS allowed prefix wasn't working because it's semantically different than FIREBASE_SECRET_REF_ and FIREBASE_MIGRATED_SYSTEM_ prefixes that need something after the underscore.